### PR TITLE
Fix engine option parsing

### DIFF
--- a/src/engines/uci_engine.cpp
+++ b/src/engines/uci_engine.cpp
@@ -108,6 +108,8 @@ void UciEngine::sendQuit()
 
 void UciEngine::sendSetoption(const std::string &name, const std::string &value)
 {
+    std::cout << "Sending option: "
+              << "setoption name " + name + " value " + value << std::endl;
     writeProcess("setoption name " + name + " value " + value);
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -114,7 +114,10 @@ void Options::parseEngineParams(int &i, int argc, char const *argv[], EngineConf
         }
         else if (isEngineSettableOption(key))
         {
-            engine_settable_options.push_back(std::make_pair(key, value));
+            // Strip option.Name of the option. Part
+            const size_t pos = key.find('.');
+            const std::string strippedKey = key.substr(pos + 1);
+            engine_settable_options.push_back(std::make_pair(strippedKey, value));
         }
         else
         {

--- a/tests/options_test.h
+++ b/tests/options_test.h
@@ -41,9 +41,9 @@ TEST_CASE("Testing Engine options parsing")
     CHECK(config0.tc.increment == 0);
     CHECK(config0.nodes == 0);
     CHECK(config0.plies == 0);
-    CHECK(config0.options.at(0).first == "option.Threads");
+    CHECK(config0.options.at(0).first == "Threads");
     CHECK(config0.options.at(0).second == "1");
-    CHECK(config0.options.at(1).first == "option.Hash");
+    CHECK(config0.options.at(1).first == "Hash");
     CHECK(config0.options.at(1).second == "16");
     CHECK(config1.name == "Alexandria-27E42728");
     CHECK(config1.tc.moves == 40);
@@ -51,9 +51,9 @@ TEST_CASE("Testing Engine options parsing")
     CHECK(config1.tc.increment == 0);
     CHECK(config1.nodes == 0);
     CHECK(config1.plies == 0);
-    CHECK(config1.options.at(0).first == "option.Threads");
+    CHECK(config1.options.at(0).first == "Threads");
     CHECK(config1.options.at(0).second == "1");
-    CHECK(config1.options.at(1).first == "option.Hash");
+    CHECK(config1.options.at(1).first == "Hash");
     CHECK(config1.options.at(1).second == "32");
 }
 


### PR DESCRIPTION
A bug in the option.X part of the engine options parsing was found, awaiting confirmation that the bug was fixed before merging.