### PR TITLE
Add total number of games and WLD % to the rating printing

### DIFF
--- a/src/tournament.cpp
+++ b/src/tournament.cpp
@@ -114,7 +114,10 @@ void Tournament::printElo()
     {
         ss << "LLR: " << sprt.getLLR(wins, draws, losses) << " " << sprt.getBounds() << "\n";
     }
-
+    ss << "Games:" << roundCount * 2 << std::setprecision(1)
+       << " W:" << (float(wins) / (roundCount * 2)) * 100 << "% "
+       << "L:" << (float(losses) / (roundCount * 2)) * 100 << "% "
+       << "D:" << (float(draws) / (roundCount * 2)) * 100 << "%\n";
     ss << "Elo difference: " << elo.getElo() << "\n---------------------------\n";
     std::cout << ss.str();
 }


### PR DESCRIPTION
Add extra info to the rating printing (most importantly the WLD %)
Example of the new output
```
Result of Alexandria-dev vs Alexandria-master: 4 - 0 - 6 (0.70)
Ptnml:        WW     WD  DD/WL     LD     LL
               1      2      2      0      0
LLR: 0.00 [-2.94 ; 2.94]
Games:10 W:40.0% L:0.0% D:60.0%
Elo difference: 147.19 +/- 134.89
```