### PR TITLE
Make nodes depth and score parsing optional

### DIFF
--- a/src/tournament.cpp
+++ b/src/tournament.cpp
@@ -221,7 +221,7 @@ bool Tournament::playNextMove(UciEngine &engine, std::string &positionInput, Boa
 
     // find bestmove and add it to the position string
     const auto bestMove =
-        findElement<std::string>(CMD::Options::splitString(output.back(), ' '), "bestmove");
+        findElement<std::string>(CMD::Options::splitString(output.back(), ' '), "bestmove").value();
 
     if (match.moves.size() == 0)
         positionInput += " moves";
@@ -525,14 +525,14 @@ MoveData Tournament::parseEngineOutput(const Board &board, const std::vector<std
     if (output.size() > 1)
     {
         const auto info = CMD::Options::splitString(output[output.size() - 2], ' ');
-
-        std::string scoreType = findElement<std::string>(info, "score");
-        depth = findElement<int>(info, "depth");
-        nodes = findElement<uint64_t>(info, "nodes");
+        // Missing elements default to 0
+        std::string scoreType = findElement<std::string>(info, "score").value_or("cp");
+        depth = findElement<int>(info, "depth").value_or(0);
+        nodes = findElement<uint64_t>(info, "nodes").value_or(0);
 
         if (scoreType == "cp")
         {
-            score = findElement<int>(info, "cp");
+            score = findElement<int>(info, "cp").value_or(0);
 
             std::stringstream ss;
             ss << (score >= 0 ? '+' : '-');
@@ -541,7 +541,7 @@ MoveData Tournament::parseEngineOutput(const Board &board, const std::vector<std
         }
         else if (scoreType == "mate")
         {
-            score = findElement<int>(info, "mate");
+            score = findElement<int>(info, "mate").value_or(0);
             score_string = (score > 0 ? "+M" : "-M") + std::to_string(std::abs(score));
             score = mate_score_;
         }

--- a/src/tournament.hpp
+++ b/src/tournament.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <fstream>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -33,9 +34,13 @@ class Tournament
     explicit Tournament(const CMD::GameManagerOptions &mc);
 
     template <typename T>
-    static T findElement(const std::vector<std::string> &haystack, std::string_view needle)
+    static std::optional<T> findElement(const std::vector<std::string> &haystack,
+                                        std::string_view needle)
     {
-        auto index = std::find(haystack.begin(), haystack.end(), needle) - haystack.begin();
+        auto position = std::find(haystack.begin(), haystack.end(), needle);
+        auto index = position - haystack.begin();
+        if (position == haystack.end())
+            return std::nullopt;
         if constexpr (std::is_same_v<T, int>)
             return std::stoi(haystack[index + 1]);
         else if constexpr (std::is_same_v<T, float>)


### PR DESCRIPTION
this makes findElement return an optional value, if the value isn't present it gets treated as  0 for pgn reporting and adjudication, it's a general fix for #93 with the downside of incomplete pgn output and broken adj for engines with more "exotic" formats. 
pgn of an engine that crashed with the previous behaviour
```
[Event "?"]
[Site "?"]
[Date "2023-03-15"]
[Round "5"]
[White "ApotheosisV1.0.1_Windows-2"]
[Black "SimpleAlex"]
[Result "0-1"]
[FEN "rnbqnrk1/ppp3bp/3p2p1/3Ppp2/2P1P3/2N1BP2/PP1Q2PP/R3KBNR w KQ f6 0 9"]
[GameDuration "00:00:19"]
[GameEndTime "2023-03-15T11:54:29 +0100"]
[GameStartTime "2023-03-15T11:54:10 +0100"]
[PlyCount "112"]
[TimeControl "8+0.08"]

1. Nge2 {+0.00/5 0.272s} f4 {+0.01/12 0.308s} 2. Bf2 {+0.00/5 0.263s} b6 {+0.01/12 0.849s} 3. O-O-O {+0.00/4 0.257s} Qf6 {+0.01/11 0.551s} 4. Nb5 {+0.00/4 0.249s} Ba6 {+0.01/11 0.260s}
5. Qb4 {+0.00/4 0.243s} Bc8 {+0.03/10 0.269s} 6. Qa4 {+0.00/4 0.236s} Bd7 {+0.01/12 0.324s} 7. Kb1 {+0.00/4 0.230s} Qf7 {+0.03/10 0.203s} 8. Nec3 {+0.00/4 0.225s} a6 {+0.03/12 0.241s} 9. Bd3 {+0.00/4 0.219s} Kh8 {+0.03/12 0.236s} 10. Qa3 {+0.00/4 0.212s} Kg8 {+0.01/11 0.190s} 11. Nxc7 {+0.00/5 0.207s} Nxc7 {-0.01/16 0.540s}
12. Qxd6 {+0.00/5 0.202s} Bc8 {-0.03/16 0.304s} 13. Qxb6 {+0.00/5 0.197s} Qd7 {-0.03/18 0.533s} 14. Bh4 {+0.00/4 0.192s} Kh8 {-0.01/13 0.347s} 15. c5 {+0.00/5 0.188s} Qf7 {-0.01/12 0.159s} 16. Rhe1 {+0.00/5 0.183s} Rg8 {-0.01/11 0.230s} 17. c6 {+0.00/4 0.180s} Bf8 {-0.01/14 0.159s} 18. Bd8 {+0.00/4 0.176s} Bd6 {+0.01/14 0.158s}
19. Bg5 {+0.00/5 0.172s} Qg7 {+0.01/13 0.152s} 20. Bc4 {+0.00/4 0.169s} Qf8 {+0.01/12 0.269s} 21. Qf2 {+0.00/4 0.164s} Kg7 {-0.01/12 0.132s} 22. Qb6 {+0.00/4 0.161s} h6 {+0.01/11 0.162s} 23. Bh4 {+0.00/5 0.159s} Ne8 {+0.01/12 0.243s} 24. Bf2 {+0.00/4 0.155s} Qe7 {+0.01/11 0.141s} 25. g3 {+0.00/4 0.152s} fxg3 {+0.01/12 0.223s}
26. hxg3 {+0.00/5 0.150s} Rf8 {+0.01/11 0.208s} 27. Qe3 {+0.00/4 0.147s} Qf6 {+0.01/11 0.106s} 28. Be2 {+0.00/4 0.143s} Bc7 {-0.01/11 0.148s} 29. Qc5 {+0.00/4 0.141s} Bd6 {+0.01/12 0.120s} 30. Qb6 {+0.00/5 0.138s} g5 {+0.01/13 0.132s} 31. Bc5 {+0.00/4 0.137s} Rf7 {-0.03/14 0.260s} 32. Rh1 {+0.00/4 0.134s} Bc7 {-0.01/13 0.110s}
33. Qb7 {+0.00/5 0.131s} Bxb7 {+1.97/15 0.108s} 34. cxb7 {+0.00/5 0.129s} Ra7 {+1.97/17 0.094s} 35. Bxa7 {+0.00/5 0.128s} Bd6 {+1.97/16 0.155s} 36. Bxb8 {+0.00/5 0.125s} Bxb8 {+1.03/13 0.110s} 37. f4 {+0.00/5 0.124s} exf4 {+2.97/12 0.092s} 38. gxf4 {+0.00/5 0.123s} gxf4 {+2.99/12 0.112s} 39. Rhg1+ {+0.00/5 0.120s} Kh8 {+2.99/12 0.135s}
40. d6 {+0.00/5 0.120s} Nxd6 {+3.01/13 0.091s} 41. Bxa6 {+0.00/5 0.118s} Nxb7 {+3.01/13 0.151s} 42. Bc4 {+0.00/5 0.116s} Rf8 {+3.01/14 0.242s} 43. Nd5 {+0.00/5 0.114s} Qe6 {+3.03/14 0.105s} 44. Rge1 {+0.00/5 0.114s} f3 {+3.97/13 0.209s} 45. b3 {+0.00/5 0.112s} f2 {+4.01/14 0.095s} 46. Re3 {+0.00/5 0.111s} Ba7 {+4.01/14 0.139s}
47. Nc3 {+0.00/5 0.109s} Qxc4 {+5.03/13 0.073s} 48. bxc4 {+0.00/6 0.108s} f1=Q {+5.03/15 0.225s} 49. Rd3 {+0.00/6 0.107s} Qf6 {+5.99/12 0.066s} 50. Nb5 {+0.00/5 0.105s} Bf2 {+6.01/13 0.082s} 51. Nd6 {+0.00/5 0.104s} Nxd6 {+10.01/14 0.097s} 52. e5 {+0.00/6 0.103s} Qxe5 {+13.03/12 0.109s} 53. Rxd6 {+0.00/5 0.103s} Rb8+ {+M4/54 0.074s}
54. Rb6 {+0.00/6 0.102s} Rxb6+ {+M3/128 0.036s} 55. Kc2 {+0.00/6 0.102s} Rb2+ {+M2/128 0.006s} 56. Kc1 {+0.00/7 0.101s} Qc3# {+M1/128 0.005s} 0-1
```
