### PR TITLE
Add seldepth tracking

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -40,6 +40,8 @@ Options::Options(int argc, char const *argv[])
                     game_options_.pgn.file = value;
                 else if (key == "tracknodes")
                     game_options_.pgn.track_nodes = true;
+                else if (key == "trackseldepth")
+                    game_options_.pgn.track_seldepth = true;
                 else if (key == "notation")
                     game_options_.pgn.notation = value;
                 else

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -31,8 +31,10 @@ struct PgnOptions
     std::string file;
     std::string notation = "san";
     bool track_nodes = false;
+    bool track_seldepth = false;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(PgnOptions, file, notation, track_nodes);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(PgnOptions, file, notation, track_nodes,
+                                                track_seldepth);
 
 struct SprtOptions
 {

--- a/src/pgn_builder.cpp
+++ b/src/pgn_builder.cpp
@@ -51,7 +51,7 @@ PgnBuilder::PgnBuilder(const Match &match, const CMD::GameManagerOptions &game_o
     {
         const MoveData data = match.moves[i];
 
-        std::stringstream nodesString, timeString;
+        std::stringstream nodesString, seldepthString, timeString;
 
         if (saveTime)
         {
@@ -63,17 +63,22 @@ PgnBuilder::PgnBuilder(const Match &match, const CMD::GameManagerOptions &game_o
             nodesString << " n=" << data.nodes;
         }
 
+        if (game_options_.pgn.track_seldepth)
+        {
+            seldepthString << " sd=" << data.seldepth;
+        }
+
         const std::string move =
             MoveToRep(b, convertUciToMove(b, data.move), game_options_.pgn.notation != "san");
 
         if (move_count % 2 != 0)
             ss << move_count / 2 << "."
                << " " << move << " {" << data.score_string << "/" << data.depth << nodesString.str()
-               << " " << timeString.str() << illegalMove.str() << "}";
+               << seldepthString.str() << " " << timeString.str() << illegalMove.str() << "}";
         else
         {
             ss << " " << move << " {" << data.score_string << "/" << data.depth << nodesString.str()
-               << " " << timeString.str() << illegalMove.str() << "}";
+               << seldepthString.str() << " " << timeString.str() << illegalMove.str() << "}";
 
             if (i == match.moves.size() - 1)
                 break;

--- a/src/tournament.cpp
+++ b/src/tournament.cpp
@@ -515,6 +515,7 @@ MoveData Tournament::parseEngineOutput(const Board &board, const std::vector<std
     uint64_t nodes = 0;
     int score = 0;
     int depth = 0;
+    int selDepth = 0;
 
     // extract last info line
     if (output.size() > 1)
@@ -523,6 +524,7 @@ MoveData Tournament::parseEngineOutput(const Board &board, const std::vector<std
         // Missing elements default to 0
         std::string scoreType = findElement<std::string>(info, "score").value_or("cp");
         depth = findElement<int>(info, "depth").value_or(0);
+        selDepth = findElement<int>(info, "seldepth").value_or(0);
         nodes = findElement<uint64_t>(info, "nodes").value_or(0);
 
         if (scoreType == "cp")
@@ -565,7 +567,7 @@ MoveData Tournament::parseEngineOutput(const Board &board, const std::vector<std
         }
     }
 
-    return MoveData(move, score_string, measuredTime, depth, score, nodes);
+    return MoveData(move, score_string, measuredTime, depth, selDepth, score, nodes);
 }
 
 void Tournament::updateTrackers(DrawAdjTracker &drawTracker, ResignAdjTracker &resignTracker,

--- a/src/tournament_data.hpp
+++ b/src/tournament_data.hpp
@@ -15,14 +15,15 @@ struct MoveData
     std::string score_string;
     int64_t elapsed_millis = 0;
     int depth = 0;
+    int seldepth = 0;
     int score = 0;
     uint64_t nodes = 0;
     MoveData() = default;
 
     MoveData(std::string _move, std::string _score_string, int64_t _elapsed_millis, int _depth,
-             int _score, int _nodes)
+             int _seldepth, int _score, int _nodes)
         : move(_move), score_string(std::move(_score_string)), elapsed_millis(_elapsed_millis),
-          depth(_depth), score(_score), nodes(_nodes)
+          depth(_depth), seldepth(_seldepth), score(_score), nodes(_nodes)
     {
     }
 };


### PR DESCRIPTION
Adds the optional tracking of seldepth, in the same vain of the node tracking, closes #99 
sample pgn excerpt
```
4. g4 {+0.01/13 n=534769 sd=25 0.267s} d5 {+1.24/13 n=357486 sd=17 0.199s}
5. Qa4 {+0.01/15 n=628412 sd=25 0.350s} e4 {+1.95/14 n=600007 sd=20 0.315s} 
6. Qxb4 {+0.01/16 n=554187 sd=26 0.247s} exd3 {+1.75/15 n=214499 sd=15 0.128s}
7. Nd4 {+0.03/16 n=342371 sd=27 0.485s} Ne5 {+1.66/16 n=852862 sd=23 0.449s}
```