### PR TITLE
feat: implement engine args

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ fast-chess supports many other command-line options:
 ### Options
 
 - `cmd=COMMAND`
+- `args="ARGS"`
+  If you want to pass multiple arguments, you can use `args="ARG1 ARG2 ARG3"`.
+  Please keep in mind that double quotes inside the string must be escaped. 
+  i.e. `args="single words \"multiple words\""` -> your engine will receive
+  ```
+  single
+  words
+  multiple words
+  ```
 - `[name=NAME]`
 - `[tc=TC]`
   TC uses the same format as Cute-Chess. For example 10+0.1 would be 10

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -58,6 +58,8 @@ void parseEngineKeyValues(EngineConfiguration &engineConfig, const std::string &
         engineConfig.limit.plies = std::stoll(value);
     else if (key == "dir")
         engineConfig.dir = value;
+    else if (key == "args")
+        engineConfig.args = value;
     else if (isEngineSettableOption(key)) {
         // Strip option.Name of the option. Part
         const std::size_t pos         = key.find('.');

--- a/src/engines/uci_engine.cpp
+++ b/src/engines/uci_engine.cpp
@@ -39,11 +39,11 @@ void UciEngine::sendSetoption(const std::string &name, const std::string &value)
 
 void UciEngine::restartEngine() {
     killProcess();
-    initProcess((config_.dir == "." ? "" : config_.dir) + config_.cmd, config_.name);
+    initProcess((config_.dir == "." ? "" : config_.dir) + config_.cmd, config_.args, config_.name);
 }
 
 void UciEngine::startEngine() {
-    initProcess((config_.dir == "." ? "" : config_.dir) + config_.cmd, config_.name);
+    initProcess((config_.dir == "." ? "" : config_.dir) + config_.cmd, config_.args, config_.name);
 
     sendUci();
 

--- a/src/third_party/communication.hpp
+++ b/src/third_party/communication.hpp
@@ -312,7 +312,7 @@ class Process : public IProcess {
             if (close(in_pipe_[1]) == -1) throw std::runtime_error("Failed to close inpipe");
 
             // Execute the engine
-            if (execl(command.c_str(), command.c_str(), args.c_str()) == -1)
+            if (execl(command.c_str(), command.c_str(), args.c_str(), NULL) == -1)
                 throw std::runtime_error("Failed to execute engine");
 
             _exit(0); /* Note that we do not use exit() */

--- a/src/third_party/communication.hpp
+++ b/src/third_party/communication.hpp
@@ -59,7 +59,8 @@ class IProcess {
     virtual ~IProcess() = default;
 
     // Initialize the process
-    virtual void initProcess(const std::string &command, const std::string &log_name) = 0;
+    virtual void initProcess(const std::string &command, const std::string &args,
+                             const std::string &log_name) = 0;
 
     /// @brief Returns true if the process is alive
     /// @return
@@ -90,7 +91,8 @@ class Process : public IProcess {
    public:
     ~Process() override { killProcess(); }
 
-    void initProcess(const std::string &command, const std::string &log_name) override {
+    void initProcess(const std::string &command, const std::string &args,
+                     const std::string &log_name) override {
         log_name_ = log_name;
 
         pi_ = PROCESS_INFORMATION();
@@ -116,8 +118,8 @@ class Process : public IProcess {
         CREATE_NEW_PROCESS_GROUP flag is important here to disable all CTRL+C signals for the new
         process
         */
-        CreateProcessA(nullptr, const_cast<char *>(command.c_str()), nullptr, nullptr, TRUE,
-                       CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi_);
+        CreateProcessA(nullptr, const_cast<char *>((command + " " + args).c_str()), nullptr,
+                       nullptr, TRUE, CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi_);
 
         CloseHandle(childStdOutWr);
         CloseHandle(childStdInRd);
@@ -272,7 +274,8 @@ class Process : public IProcess {
    public:
     ~Process() override { killProcess(); }
 
-    void initProcess(const std::string &command, const std::string &log_name) override {
+    void initProcess(const std::string &command, const std::string &args,
+                     const std::string &log_name) override {
         is_initalized_ = true;
         log_name_      = log_name;
         // Create input pipe
@@ -309,7 +312,7 @@ class Process : public IProcess {
             if (close(in_pipe_[1]) == -1) throw std::runtime_error("Failed to close inpipe");
 
             // Execute the engine
-            if (execl(command.c_str(), command.c_str(), (char *)NULL) == -1)
+            if (execl(command.c_str(), command.c_str(), args.c_str()) == -1)
                 throw std::runtime_error("Failed to execute engine");
 
             _exit(0); /* Note that we do not use exit() */

--- a/tests/data/engine/dummy_engine.cpp
+++ b/tests/data/engine/dummy_engine.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 int main() {
     std::vector<std::string> moves = {"f2f3", "e7e5", "g2g4", "d8h4"};
-    int moveIndex = 0;
+    int moveIndex                  = 0;
 
     while (true) {
         string cmd;


### PR DESCRIPTION
usage:

```
.\fast-chess.exe -engine cmd=random_mover name=random_move_1 \
 -engine cmd=random_mover name=random_move_2 \
 -each tc=2+0.02s args="single words \"multiple words\"" -rounds 1 -repeat -concurrency 4 \
 -openings file=tests/e2e/openings.epd format=epd order=random
```` 

closes https://github.com/Disservin/fast-chess/issues/139