### PR TITLE
refactor: improve windows readProcess speed

### DIFF
--- a/src/process/process_posix.hpp
+++ b/src/process/process_posix.hpp
@@ -217,7 +217,7 @@ class Process : public IProcess {
                             return Status::OK;
                         }
 
-                        currentLine = "";
+                        currentLine.clear();
                     }
                 }
             }


### PR DESCRIPTION
while async itself also adds some overhead it seems that this is still an improvement over the PeekNamedPipe approach