### PR TITLE
nelo bounds for SPRT

### DIFF
--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -28,14 +28,39 @@ SPRT::SPRT(double alpha, double beta, double elo0, double elo1) {
 double SPRT::getLL(double elo) noexcept { return 1.0 / (1.0 + std::pow(10.0, -elo / 400.0)); }
 
 double SPRT::getLLR(int win, int draw, int loss) const noexcept {
-    if (win == 0 || draw == 0 || loss == 0 || !valid_) return 0.0;
+    if (!valid_) return 0.0;
 
     const double games = win + draw + loss;
+    if (games == 0) return 0.0;
     const double W = double(win) / games, D = double(draw) / games;
     const double a     = W + D / 2;
     const double b     = W + D / 4;
     const double var   = b - std::pow(a, 2);
+    if (var == 0) return 0.0;
     const double var_s = var / games;
+    return (s1_ - s0_) * (2 * a - s0_ - s1_) / var_s / 2.0;
+}
+
+double SPRT::getPentaLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) const noexcept {
+    if (!valid_) return 0.0;
+
+    const double pairs = penta_WW + penta_WD + penta_WL + penta_DD + penta_LD + penta_LL;
+    if (pairs == 0) return 0.0;
+    const double WW = double(penta_WW) / pairs; 
+    const double WD = double(penta_WD) / pairs; 
+    const double WL = double(penta_WL) / pairs; 
+    const double DD = double(penta_DD) / pairs;
+    const double LD = double(penta_LD) / pairs;
+    const double LL = double(penta_LL) / pairs;
+    const double a = WW + 0.75 * WD + 0.5 * (WL + DD) + 0.25 * LD;
+    const double WW_dev = WW * std::pow((1 - a), 2);
+    const double WD_dev = WD * std::pow((0.75 - a), 2);
+    const double WLDD_dev = (WL + DD) * std::pow((0.5 - a), 2);
+    const double LD_dev = LD * std::pow((0.25 - a), 2);
+    const double LL_dev = LL * std::pow((0 - a), 2);
+    const double var   = WW_dev + WD_dev + WLDD_dev + LD_dev + LL_dev;
+    if (var == 0) return 0.0;
+    const double var_s = var / pairs;
     return (s1_ - s0_) * (2 * a - s0_ - s1_) / var_s / 2.0;
 }
 

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -58,10 +58,10 @@ double SPRT::getPentaLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD,
     const double WLDD_dev = (WL + DD) * std::pow((0.5 - a), 2);
     const double LD_dev = LD * std::pow((0.25 - a), 2);
     const double LL_dev = LL * std::pow((0 - a), 2);
-    const double var   = WW_dev + WD_dev + WLDD_dev + LD_dev + LL_dev;
-    if (var == 0) return 0.0;
-    const double var_s = var / pairs;
-    return (s1_ - s0_) * (2 * a - s0_ - s1_) / var_s / 2.0;
+    const double var_penta   = WW_dev + WD_dev + WLDD_dev + LD_dev + LL_dev;
+    if (var_penta == 0) return 0.0;
+    const double var_s_penta = var_penta / pairs;
+    return (s1_ - s0_) * (2 * a - s0_ - s1_) / var_s_penta / 2.0;
 }
 
 SPRTResult SPRT::getResult(double llr) const noexcept {

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -14,7 +14,7 @@ class SPRT {
 
     [[nodiscard]] bool isValid() const noexcept;
 
-    [[nodiscard]] static double getLL(double elo) noexcept;
+    [[nodiscard]] static double neloToScore(double nelo, double stdDeviation) noexcept;
     [[nodiscard]] double getLLR(int win, int draw, int loss) const noexcept;
     [[nodiscard]] double getPentaLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) const noexcept;
 

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -16,6 +16,7 @@ class SPRT {
 
     [[nodiscard]] static double getLL(double elo) noexcept;
     [[nodiscard]] double getLLR(int win, int draw, int loss) const noexcept;
+    [[nodiscard]] double getPentaLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) const noexcept;
 
     [[nodiscard]] SPRTResult getResult(double llr) const noexcept;
     [[nodiscard]] std::string getBounds() const noexcept;

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -25,8 +25,6 @@ class SPRT {
    private:
     double lower_ = 0.0;
     double upper_ = 0.0;
-    double s0_    = 0.0;
-    double s1_    = 0.0;
 
     double elo0_ = 0.0;
     double elo1_ = 0.0;


### PR DESCRIPTION
makes the elo0 and elo1 bounds for SPRT use normalized elo like in fishtest instead of logistic elo. this allows fastchess to directly use fishtest elo SPRT bounds.