### PR TITLE
feat: replace trinomial stats with pentanomial stats

### DIFF
--- a/src/matchmaking/elo/elo.cpp
+++ b/src/matchmaking/elo/elo.cpp
@@ -47,8 +47,8 @@ double Elo::getError(int wins, int losses, int draws) noexcept {
     const double devD  = d * std::pow(0.5 - perc, 2.0);
     const double stdev = std::sqrt(devW + devL + devD) / std::sqrt(n);
 
-    const double devMin = perc + phiInv(0.025) * stdev;
-    const double devMax = perc + phiInv(0.975) * stdev;
+    const double devMin = a + phiInv(0.025) * stdev;
+    const double devMax = a + phiInv(0.975) * stdev;
     return (percToEloDiff(devMax) - percToEloDiff(devMin)) / 2.0;
 }
 
@@ -88,7 +88,6 @@ double Elo::getDiff(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int 
     const double WL = double(penta_WL) / pairs; 
     const double DD = double(penta_DD) / pairs;
     const double LD = double(penta_LD) / pairs;
-    const double LL = double(penta_LL) / pairs;
     const double percentage = WW + 0.75 * WD + 0.5 * (WL + DD) + 0.25 * LD;
 
     return percToEloDiff(percentage);

--- a/src/matchmaking/elo/elo.cpp
+++ b/src/matchmaking/elo/elo.cpp
@@ -161,7 +161,6 @@ std::string Elo::getScoreRatio(int penta_WW, int penta_WD, int penta_WL, int pen
     const double WL = double(penta_WL) / pairs; 
     const double DD = double(penta_DD) / pairs;
     const double LD = double(penta_LD) / pairs;
-    const double LL = double(penta_LL) / pairs;
     const double scoreRatio = WW + 0.75 * WD + 0.5 * (WL + DD) + 0.25 * LD;
 
     std::stringstream ss;

--- a/src/matchmaking/elo/elo.cpp
+++ b/src/matchmaking/elo/elo.cpp
@@ -47,8 +47,8 @@ double Elo::getError(int wins, int losses, int draws) noexcept {
     const double devD  = d * std::pow(0.5 - perc, 2.0);
     const double stdev = std::sqrt(devW + devL + devD) / std::sqrt(n);
 
-    const double devMin = a + phiInv(0.025) * stdev;
-    const double devMax = a + phiInv(0.975) * stdev;
+    const double devMin = perc + phiInv(0.025) * stdev;
+    const double devMax = perc + phiInv(0.975) * stdev;
     return (percToEloDiff(devMax) - percToEloDiff(devMin)) / 2.0;
 }
 
@@ -68,8 +68,8 @@ double Elo::getError(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int
     const double LL_dev = LL * std::pow((0 - a), 2);
     const double stdev = std::sqrt(WW_dev + WD_dev + WLDD_dev + LD_dev + LL_dev) / std::sqrt(pairs);
 
-    const double devMin = perc + phiInv(0.025) * stdev;
-    const double devMax = perc + phiInv(0.975) * stdev;
+    const double devMin = a + phiInv(0.025) * stdev;
+    const double devMax = a + phiInv(0.975) * stdev;
     return (percToEloDiff(devMax) - percToEloDiff(devMin)) / 2.0;
 }
 

--- a/src/matchmaking/elo/elo.hpp
+++ b/src/matchmaking/elo/elo.hpp
@@ -9,10 +9,6 @@ class Elo {
 
     Elo(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL);
 
-    [[nodiscard]] static double inverseError(double x) noexcept;
-
-    [[nodiscard]] static double phiInv(double p) noexcept;
-
     [[nodiscard]] static double percToEloDiff(double percentage) noexcept;
 
     [[nodiscard]] static double getDiff(int wins, int losses, int draws) noexcept;
@@ -25,7 +21,7 @@ class Elo {
 
     [[nodiscard]] std::string getElo() const noexcept;
 
-    [[nodiscard]] static std::string getLos(int wins, int losses) noexcept;
+    [[nodiscard]] static std::string getLos(int wins, int losses, int draws) noexcept;
 
     [[nodiscard]] static std::string getLos(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
 

--- a/src/matchmaking/elo/elo.hpp
+++ b/src/matchmaking/elo/elo.hpp
@@ -7,6 +7,8 @@ class Elo {
    public:
     Elo(int wins, int losses, int draws);
 
+    Elo(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL);
+
     [[nodiscard]] static double inverseError(double x) noexcept;
 
     [[nodiscard]] static double phiInv(double p) noexcept;
@@ -15,15 +17,25 @@ class Elo {
 
     [[nodiscard]] static double getDiff(int wins, int losses, int draws) noexcept;
 
+    [[nodiscard]] static double getDiff(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
+
     [[nodiscard]] static double getError(int wins, int losses, int draws) noexcept;
+
+    [[nodiscard]] static double getError(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
 
     [[nodiscard]] std::string getElo() const noexcept;
 
     [[nodiscard]] static std::string getLos(int wins, int losses) noexcept;
 
+    [[nodiscard]] static std::string getLos(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
+
     [[nodiscard]] static std::string getDrawRatio(int wins, int losses, int draws) noexcept;
 
+    [[nodiscard]] static std::string getDrawRatio(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
+
     [[nodiscard]] static std::string getScoreRatio(int wins, int losses, int draws) noexcept;
+
+    [[nodiscard]] static std::string getScoreRatio(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
 
    private:
     double diff_;

--- a/src/matchmaking/output/output_cutechess.hpp
+++ b/src/matchmaking/output/output_cutechess.hpp
@@ -39,7 +39,7 @@ class Cutechess : public IOutput {
            << elo.getElo()                                              //
            << ", "                                                      //
            << "LOS: "                                                   //
-           << Elo::getLos(stats.wins, stats.losses)                     //
+           << Elo::getLos(stats.wins, stats.losses, stats.draws)        //
            << ", "                                                      //
            << "DrawRatio: "                                             //
            << Elo::getDrawRatio(stats.wins, stats.losses, stats.draws)  //

--- a/src/matchmaking/output/output_cutechess.hpp
+++ b/src/matchmaking/output/output_cutechess.hpp
@@ -16,7 +16,7 @@ class Cutechess : public IOutput {
 
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
                   std::size_t current_game_count) override {
-        const Elo elo(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL);
+        const Elo elo(stats.wins, stats.losses, stats.draws);
 
         std::stringstream ss;
         ss << "Score of "                                                //
@@ -30,7 +30,7 @@ class Cutechess : public IOutput {
            << " - "                                                      //
            << stats.draws                                                //
            << " ["                                                       //
-           << Elo::getScoreRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)  //
+           << Elo::getScoreRatio(stats.wins, stats.losses, stats.draws)  //
            << "] "                                                       //
            << current_game_count                                         //
            << "\n";
@@ -39,10 +39,10 @@ class Cutechess : public IOutput {
            << elo.getElo()                                              //
            << ", "                                                      //
            << "LOS: "                                                   //
-           << Elo::getLos(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)        //
+           << Elo::getLos(stats.wins, stats.losses, stats.draws)        //
            << ", "                                                      //
-           << "PairDrawRatio: "                                         //
-           << Elo::getDrawRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)  //
+           << "DrawRatio: "                                         //
+           << Elo::getDrawRatio(stats.wins, stats.losses, stats.draws)  //
            << "\n";
 
         std::cout << ss.str() << std::flush;

--- a/src/matchmaking/output/output_cutechess.hpp
+++ b/src/matchmaking/output/output_cutechess.hpp
@@ -41,7 +41,7 @@ class Cutechess : public IOutput {
            << "LOS: "                                                   //
            << Elo::getLos(stats.wins, stats.losses, stats.draws)        //
            << ", "                                                      //
-           << "DrawRatio: "                                         //
+           << "DrawRatio: "                                             //
            << Elo::getDrawRatio(stats.wins, stats.losses, stats.draws)  //
            << "\n";
 

--- a/src/matchmaking/output/output_cutechess.hpp
+++ b/src/matchmaking/output/output_cutechess.hpp
@@ -16,7 +16,7 @@ class Cutechess : public IOutput {
 
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
                   std::size_t current_game_count) override {
-        const Elo elo(stats.wins, stats.losses, stats.draws);
+        const Elo elo(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL);
 
         std::stringstream ss;
         ss << "Score of "                                                //
@@ -30,7 +30,7 @@ class Cutechess : public IOutput {
            << " - "                                                      //
            << stats.draws                                                //
            << " ["                                                       //
-           << Elo::getScoreRatio(stats.wins, stats.losses, stats.draws)  //
+           << Elo::getScoreRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)  //
            << "] "                                                       //
            << current_game_count                                         //
            << "\n";
@@ -39,10 +39,10 @@ class Cutechess : public IOutput {
            << elo.getElo()                                              //
            << ", "                                                      //
            << "LOS: "                                                   //
-           << Elo::getLos(stats.wins, stats.losses, stats.draws)        //
+           << Elo::getLos(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)        //
            << ", "                                                      //
-           << "DrawRatio: "                                             //
-           << Elo::getDrawRatio(stats.wins, stats.losses, stats.draws)  //
+           << "PairDrawRatio: "                                         //
+           << Elo::getDrawRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)  //
            << "\n";
 
         std::cout << ss.str() << std::flush;

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -19,7 +19,7 @@ class Fastchess : public IOutput {
 
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
                   std::size_t current_game_count) override {
-        const Elo elo(stats.wins, stats.losses, stats.draws);
+        const Elo elo(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL);
 
         std::stringstream ss;
         ss << "Score of "                                                //
@@ -33,7 +33,7 @@ class Fastchess : public IOutput {
            << " - "                                                      //
            << stats.draws                                                //
            << " ["                                                       //
-           << Elo::getScoreRatio(stats.wins, stats.losses, stats.draws)  //
+           << Elo::getScoreRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)  //
            << "] "                                                       //
            << current_game_count                                         //
            << "\n";
@@ -42,10 +42,10 @@ class Fastchess : public IOutput {
            << elo.getElo()                                              //
            << ", "                                                      //
            << "LOS: "                                                   //
-           << Elo::getLos(stats.wins, stats.losses, stats.draws)        //
+           << Elo::getLos(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)        //
            << ", "                                                      //
-           << "DrawRatio: "                                             //
-           << Elo::getDrawRatio(stats.wins, stats.losses, stats.draws)  //
+           << "PairDrawRatio: "                                         //
+           << Elo::getDrawRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)  //
            << "\n";
 
         std::cout << ss.str() << std::flush;

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -42,7 +42,7 @@ class Fastchess : public IOutput {
            << elo.getElo()                                              //
            << ", "                                                      //
            << "LOS: "                                                   //
-           << Elo::getLos(stats.wins, stats.losses)                     //
+           << Elo::getLos(stats.wins, stats.losses, stats.draws)        //
            << ", "                                                      //
            << "DrawRatio: "                                             //
            << Elo::getDrawRatio(stats.wins, stats.losses, stats.draws)  //


### PR DESCRIPTION
statistics functions are now overloaded so they can be called with pentanomial results. this would spit out pentanomial elo, error margins, draw ratio, score ratio, and LOS.

Edit: added better approximation for trinomial LOS since the last one by remi coulom doesnt include draw information and is made for convenience of calculation: https://www.talkchess.com/forum/viewtopic.php?t=51003&start=5 . Also replaced the entire phiinv function with the actual value for 95% confidence interval.