### PR TITLE
Set default SPRT mode to pentanomial

### DIFF
--- a/man
+++ b/man
@@ -89,7 +89,7 @@ OPTIONS
             Set the rating interval for the rating report. For penta reports, this is reports per N game pair.
 
         -sprt elo0=ELO0 elo1=ELO1 alpha=ALPHA beta=BETA
-            Set parameters for the Sequential Probability Ratio Test (SPRT). elo0 and elo1 is in the form of normalized elo (nElo).
+            Set parameters for the Sequential Probability Ratio Test (SPRT).
 
         -srand SEED
             Set the seed for the random number generator.

--- a/man
+++ b/man
@@ -89,7 +89,7 @@ OPTIONS
             Set the rating interval for the rating report. For penta reports, this is reports per N game pair.
 
         -sprt elo0=ELO0 elo1=ELO1 alpha=ALPHA beta=BETA
-            Set parameters for the Sequential Probability Ratio Test (SPRT).
+            Set parameters for the Sequential Probability Ratio Test (SPRT). elo0 and elo1 is in the form of normalized elo (nElo).
 
         -srand SEED
             Set the seed for the random number generator.

--- a/src/matchmaking/output/output_cutechess.hpp
+++ b/src/matchmaking/output/output_cutechess.hpp
@@ -53,7 +53,7 @@ class Cutechess : public IOutput {
             std::stringstream ss;
 
             ss << "LLR: " << std::fixed << std::setprecision(2)
-               << sprt.getLLR(stats.wins, stats.draws, stats.losses) << " " << sprt.getBounds()
+               << sprt.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL) << " " << sprt.getBounds()
                << " " << sprt.getElo() << "\n";
             std::cout << ss.str() << std::flush;
         }

--- a/src/matchmaking/output/output_cutechess.hpp
+++ b/src/matchmaking/output/output_cutechess.hpp
@@ -53,7 +53,7 @@ class Cutechess : public IOutput {
             std::stringstream ss;
 
             ss << "LLR: " << std::fixed << std::setprecision(2)
-               << sprt.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL) << " " << sprt.getBounds()
+               << sprt.getLLR(stats.wins, stats.draws, stats.losses) << " " << sprt.getBounds()
                << " " << sprt.getElo() << "\n";
             std::cout << ss.str() << std::flush;
         }

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -56,7 +56,7 @@ class Fastchess : public IOutput {
             std::stringstream ss;
 
             ss << "LLR: " << std::fixed << std::setprecision(2)
-               << sprt.getLLR(stats.wins, stats.draws, stats.losses) << " " << sprt.getBounds()
+               << sprt.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL) << " " << sprt.getBounds()
                << " " << sprt.getElo() << "\n";
             std::cout << ss.str() << std::flush;
         }
@@ -66,18 +66,18 @@ class Fastchess : public IOutput {
         std::stringstream ss;
 
         ss << "Ptnml:   " << std::right << std::setw(7)  //
-           << "WW" << std::right << std::setw(7)         //
-           << "WD" << std::right << std::setw(7)         //
-           << "DD/WL" << std::right << std::setw(7)      //
+           << "LL" << std::right << std::setw(7)         //
            << "LD" << std::right << std::setw(7)         //
-           << "LL"
+           << "DD/WL" << std::right << std::setw(7)      //
+           << "WD" << std::right << std::setw(7)         //
+           << "WW"
            << "\n"
            << "Distr:   " << std::right << std::setw(7)                      //
-           << stats.penta_WW << std::right << std::setw(7)                   //
-           << stats.penta_WD << std::right << std::setw(7)                   //
-           << stats.penta_WL + stats.penta_DD << std::right << std::setw(7)  //
+           << stats.penta_LL << std::right << std::setw(7)                   //
            << stats.penta_LD << std::right << std::setw(7)                   //
-           << stats.penta_LL << "\n";
+           << stats.penta_WL + stats.penta_DD << std::right << std::setw(7)  //
+           << stats.penta_WD << std::right << std::setw(7)                   //
+           << stats.penta_WW << "\n";
         std::cout << ss.str() << std::flush;
     }
 

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -39,8 +39,8 @@ double SPRT::getLLR(int win, int draw, int loss) const noexcept {
     if (var == 0) return 0.0;
     const double stdDeviation = std::sqrt(var);
     const double var_s = var / games;
-    const double score0 = neloToScore(elo0_, stdDeviation);
-    const double score1 = neloToScore(elo1_, stdDeviation);
+    const double score0 = neloToScoreWDL(elo0_, stdDeviation);
+    const double score1 = neloToScoreWDL(elo1_, stdDeviation);
     return (score1 - score0) * (2 * a - score0 - score1) / var_s / 2.0;
 }
 
@@ -65,8 +65,8 @@ double SPRT::getLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int 
     if (var_penta == 0) return 0.0;
     const double stdDeviation_penta = std::sqrt(var_penta);
     const double var_s_penta = var_penta / pairs;
-    const double score0 = neloToScore(elo0_, stdDeviation_penta);
-    const double score1 = neloToScore(elo1_, stdDeviation_penta);
+    const double score0 = neloToScorePenta(elo0_, stdDeviation_penta);
+    const double score1 = neloToScorePenta(elo1_, stdDeviation_penta);
     return (score1 - score0) * (2 * a - score0 - score1) / var_s_penta / 2.0;
 }
 

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -23,7 +23,9 @@ SPRT::SPRT(double alpha, double beta, double elo0, double elo1) {
     }
 }
 
-double SPRT::neloToScore(double nelo, double stdDeviation) noexcept { return nelo * (std::sqrt(2.0) * stdDeviation) / (800.0 / std::log(10)) + 0.5; }
+double SPRT::neloToScoreWDL(double nelo, double stdDeviation) noexcept { return nelo * stdDeviation / (800.0 / std::log(10)) + 0.5; }
+
+double SPRT::neloToScorePenta(double nelo, double stdDeviation) noexcept { return nelo * (std::sqrt(2.0) * stdDeviation) / (800.0 / std::log(10)) + 0.5; }
 
 double SPRT::getLLR(int win, int draw, int loss) const noexcept {
     if (!valid_) return 0.0;

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -14,7 +14,8 @@ class SPRT {
 
     [[nodiscard]] bool isValid() const noexcept;
 
-    [[nodiscard]] static double neloToScore(double nelo, double stdDeviation) noexcept;
+    [[nodiscard]] static double neloToScoreWDL(double nelo, double stdDeviation) noexcept;
+    [[nodiscard]] static double neloToScorePenta(double nelo, double stdDeviation) noexcept;
     [[nodiscard]] double getLLR(int win, int draw, int loss) const noexcept;
     [[nodiscard]] double getLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) const noexcept;
 

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -119,7 +119,7 @@ void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine
 
     const auto stats = result_.getStats(engine_configs[0].name, engine_configs[1].name);
     const auto llr = tournament_options_.report_penta ? sprt_.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL) 
-                                                      : sprt_.getLLR(stats.wins, stats.losses, stats.draws);
+                                                      : sprt_.getLLR(stats.wins, stats.draws, stats.losses);
   
     if (sprt_.getResult(llr) != SPRT_CONTINUE || match_count_ == total_) {
         atomic::stop = true;

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -118,8 +118,9 @@ void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine
     if (!sprt_.isValid()) return;
 
     const auto stats = result_.getStats(engine_configs[0].name, engine_configs[1].name);
-    const auto llr   = sprt_.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL);
-
+    const auto llr = tournament_options_.report_penta ? sprt_.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL) 
+                                                      : sprt_.getLLR(stats.wins, stats.losses, stats.draws);
+  
     if (sprt_.getResult(llr) != SPRT_CONTINUE || match_count_ == total_) {
         atomic::stop = true;
 

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -118,7 +118,7 @@ void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine
     if (!sprt_.isValid()) return;
 
     const auto stats = result_.getStats(engine_configs[0].name, engine_configs[1].name);
-    const auto llr   = sprt_.getLLR(stats.wins, stats.draws, stats.losses);
+    const auto llr   = sprt_.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL);
 
     if (sprt_.getResult(llr) != SPRT_CONTINUE || match_count_ == total_) {
         atomic::stop = true;


### PR DESCRIPTION
also flip the pentanomial output from 2-0 to 0-2 to be more consistent with fishtest and Openbench.