### PR TITLE
add nelo statistic and annotate WDL result in fastchess output

### DIFF
--- a/src/matchmaking/elo/elo.cpp
+++ b/src/matchmaking/elo/elo.cpp
@@ -25,11 +25,11 @@ double Elo::percToEloDiff(double percentage) noexcept {
 }
 
 double Elo::percToNeloDiff(double percentage, double stdev) noexcept {
-    return (perc - 0.5) / (std::sqrt(2) * stdev) * (800 / std::log(10));
+    return (percentage - 0.5) / (std::sqrt(2) * stdev) * (800 / std::log(10));
 }
 
 double Elo::percToNeloDiffWDL(double percentage, double stdev) noexcept {
-    return (perc - 0.5) / stdev * (800 / std::log(10));
+    return (percentage - 0.5) / stdev * (800 / std::log(10));
 }
 
 double Elo::getError(int wins, int losses, int draws) noexcept {

--- a/src/matchmaking/elo/elo.cpp
+++ b/src/matchmaking/elo/elo.cpp
@@ -158,7 +158,7 @@ double Elo::getneloDiff(int penta_WW, int penta_WD, int penta_WL, int penta_DD, 
     const double LL_dev = LL * std::pow((0 - a), 2);
     const double stdev = std::sqrt(WW_dev + WD_dev + WLDD_dev + LD_dev + LL_dev) / std::sqrt(pairs);
 
-    return percToNeloDiff(percentage, stdev * std::sqrt(pairs));
+    return percToNeloDiff(a, stdev * std::sqrt(pairs));
 }
 
 std::string Elo::getElo() const noexcept {

--- a/src/matchmaking/elo/elo.cpp
+++ b/src/matchmaking/elo/elo.cpp
@@ -9,6 +9,8 @@ namespace fast_chess {
 Elo::Elo(int wins, int losses, int draws) {
     diff_  = getDiff(wins, losses, draws);
     error_ = getError(wins, losses, draws);
+    nelodiff_  = getneloDiff(wins, losses, draws);
+    neloerror_ = getneloError(wins, losses, draws);
 }
 
 Elo::Elo(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) {
@@ -26,6 +28,10 @@ double Elo::percToNeloDiff(double percentage, double stdev) noexcept {
     return (perc - 0.5) / (std::sqrt(2) * stdev) * (800 / std::log(10));
 }
 
+double Elo::percToNeloDiffWDL(double percentage, double stdev) noexcept {
+    return (perc - 0.5) / stdev * (800 / std::log(10));
+}
+
 double Elo::getError(int wins, int losses, int draws) noexcept {
     const double n    = wins + losses + draws;
     const double w    = wins / n;
@@ -41,6 +47,23 @@ double Elo::getError(int wins, int losses, int draws) noexcept {
     const double devMin = perc - 1.959963984540054 * stdev;
     const double devMax = perc + 1.959963984540054 * stdev;
     return (percToEloDiff(devMax) - percToEloDiff(devMin)) / 2.0;
+}
+
+double Elo::getneloError(int wins, int losses, int draws) noexcept {
+    const double n    = wins + losses + draws;
+    const double w    = wins / n;
+    const double l    = losses / n;
+    const double d    = draws / n;
+    const double perc = w + d / 2.0;
+
+    const double devW  = w * std::pow(1.0 - perc, 2.0);
+    const double devL  = l * std::pow(0.0 - perc, 2.0);
+    const double devD  = d * std::pow(0.5 - perc, 2.0);
+    const double stdev = std::sqrt(devW + devL + devD) / std::sqrt(n);
+
+    const double devMin = perc - 1.959963984540054 * stdev;
+    const double devMax = perc + 1.959963984540054 * stdev;
+    return (percToNeloDiffWDL(devMax, stdev * std::sqrt(n)) - percToNeloDiffWDL(devMin, stdev * std::sqrt(n))) / 2.0;
 }
 
 double Elo::getError(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept {
@@ -91,6 +114,20 @@ double Elo::getDiff(int wins, int losses, int draws) noexcept {
     const double percentage = (score / n);
 
     return percToEloDiff(percentage);
+}
+
+double Elo::getneloDiff(int wins, int losses, int draws) noexcept {
+    const double n    = wins + losses + draws;
+    const double w    = wins / n;
+    const double l    = losses / n;
+    const double d    = draws / n;
+    const double perc = w + d / 2.0;
+
+    const double devW  = w * std::pow(1.0 - perc, 2.0);
+    const double devL  = l * std::pow(0.0 - perc, 2.0);
+    const double devD  = d * std::pow(0.5 - perc, 2.0);
+    const double stdev = std::sqrt(devW + devL + devD) / std::sqrt(n);
+    return percToNeloDiffWDL(perc, stdev * std::sqrt(n));
 }
 
 double Elo::getDiff(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept {

--- a/src/matchmaking/elo/elo.hpp
+++ b/src/matchmaking/elo/elo.hpp
@@ -11,15 +11,23 @@ class Elo {
 
     [[nodiscard]] static double percToEloDiff(double percentage) noexcept;
 
+    [[nodiscard]] static double percToNeloDiff(double percentage, double stdev) noexcept;
+
     [[nodiscard]] static double getDiff(int wins, int losses, int draws) noexcept;
 
     [[nodiscard]] static double getDiff(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
+
+    [[nodiscard]] static double getneloDiff(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
 
     [[nodiscard]] static double getError(int wins, int losses, int draws) noexcept;
 
     [[nodiscard]] static double getError(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
 
+    [[nodiscard]] static double getneloError(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
+
     [[nodiscard]] std::string getElo() const noexcept;
+
+    [[nodiscard]] std::string getnElo() const noexcept;
 
     [[nodiscard]] static std::string getLos(int wins, int losses, int draws) noexcept;
 
@@ -36,6 +44,8 @@ class Elo {
    private:
     double diff_;
     double error_;
+    double nelodiff_;
+    double neloerror_;
 };
 
 }  // namespace fast_chess

--- a/src/matchmaking/elo/elo.hpp
+++ b/src/matchmaking/elo/elo.hpp
@@ -13,15 +13,21 @@ class Elo {
 
     [[nodiscard]] static double percToNeloDiff(double percentage, double stdev) noexcept;
 
+    [[nodiscard]] static double percToNeloDiffWDL(double percentage, double stdev) noexcept;
+
     [[nodiscard]] static double getDiff(int wins, int losses, int draws) noexcept;
 
     [[nodiscard]] static double getDiff(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
+
+    [[nodiscard]] static double getneloDiff(int wins, int losses, int draws) noexcept;
 
     [[nodiscard]] static double getneloDiff(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
 
     [[nodiscard]] static double getError(int wins, int losses, int draws) noexcept;
 
     [[nodiscard]] static double getError(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
+
+    [[nodiscard]] static double getneloError(int wins, int losses, int draws) noexcept;
 
     [[nodiscard]] static double getneloError(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD, int penta_LL) noexcept;
 

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -28,11 +28,11 @@ class Fastchess : public IOutput {
            << second                                                     //
            << ": "                                                       //
            << stats.wins                                                 //
-           << " - "                                                      //
+           << "W - "                                                      //
            << stats.losses                                               //
-           << " - "                                                      //
+           << "L - "                                                      //
            << stats.draws                                                //
-           << " ["                                                       //
+           << "D ["                                                       //
            << Elo::getScoreRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)  //
            << "] "                                                       //
            << current_game_count                                         //
@@ -40,6 +40,9 @@ class Fastchess : public IOutput {
 
         ss << "Elo difference: "                                        //
            << elo.getElo()                                              //
+           << ", "                                                      //
+           << "nElo difference: "                                       //
+           << elo.getnElo()                                             //
            << ", "                                                      //
            << "LOS: "                                                   //
            << Elo::getLos(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD, stats.penta_LD, stats.penta_LL)        //


### PR DESCRIPTION
Note: error margins for nElo are calculated differently from fishtest. in fishtest the skewness and excess kurtosis of the bell curve is taken into account while in here a perfect bell curve is assumed for ease of calculation. this makes it less accurate but the differences are very slight (probably around 0.1 elo at most).

output looks like this:
![Screenshot 2024-04-13 063709](https://github.com/Disservin/fast-chess/assets/155860115/bd605330-511d-45b8-bbd7-f2ca5840a8ab)
