### PR TITLE
optional parameter for logistic elo SPRT bounds

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -249,6 +249,12 @@ void parseSprt(int &i, int argc, char const *argv[], ArgumentData &argument_data
             argument_data.tournament_options.sprt.alpha = std::stod(value);
         } else if (key == "beta") {
             argument_data.tournament_options.sprt.beta = std::stod(value);
+        } else if (key == "bounds") {
+            if (value == "logistic"){
+              argument_data.tournament_options.sprt.bounds = true;
+            } else if (value == "normalized"){
+              argument_data.tournament_options.sprt.bounds = false;
+            } else {OptionsParser::throwMissing("sprt", key, value);}
         } else {
             OptionsParser::throwMissing("sprt", key, value);
         }

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -23,6 +23,10 @@ SPRT::SPRT(double alpha, double beta, double elo0, double elo1) {
     }
 }
 
+double SPRT::leloToScore(double lelo) noexcept {
+    return 1 / (1 + std::pow(10, (-lelo / 400)));
+}
+
 double SPRT::neloToScoreWDL(double nelo, double stdDeviation) noexcept {
     return nelo * stdDeviation / (800.0 / std::log(10)) + 0.5;
 }
@@ -43,8 +47,17 @@ double SPRT::getLLR(int win, int draw, int loss) const noexcept {
     if (var == 0) return 0.0;
     const double stdDeviation = std::sqrt(var);
     const double var_s        = var / games;
-    const double score0       = neloToScoreWDL(elo0_, stdDeviation);
-    const double score1       = neloToScoreWDL(elo1_, stdDeviation);
+    if (bounds == "normalized") {
+        const double score0       = neloToScoreWDL(elo0_, stdDeviation);
+        const double score1       = neloToScoreWDL(elo1_, stdDeviation);
+    }
+    else if (bounds== "logistic") {
+        const double score0       = leloToScore(elo0_, stdDeviation);
+        const double score1       = leloToScore(elo1_, stdDeviation);
+    }
+    else {
+        return 0.0;
+    }
     return (score1 - score0) * (2 * a - score0 - score1) / var_s / 2.0;
 }
 
@@ -70,8 +83,17 @@ double SPRT::getLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int 
     if (var_penta == 0) return 0.0;
     const double stdDeviation_penta = std::sqrt(var_penta);
     const double var_s_penta        = var_penta / pairs;
-    const double score0             = neloToScorePenta(elo0_, stdDeviation_penta);
-    const double score1             = neloToScorePenta(elo1_, stdDeviation_penta);
+    if (bounds == "normalized") {
+        const double score0       = neloToScorePenta(elo0_, stdDeviation_penta);
+        const double score1       = neloToScorePenta(elo1_, stdDeviation_penta);
+    }
+    else if (bounds== "logistic") {
+        const double score0       = leloToScore(elo0_, stdDeviation_penta);
+        const double score1       = leloToScore(elo1_, stdDeviation_penta);
+    }
+    else {
+        return 0.0;
+    }
     return (score1 - score0) * (2 * a - score0 - score1) / var_s_penta / 2.0;
 }
 

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -49,8 +49,8 @@ double SPRT::getLLR(int win, int draw, int loss) const noexcept {
     if (var == 0) return 0.0;
     const double stdDeviation = std::sqrt(var);
     const double var_s        = var / games;
-    const double score0;
-    const double score1;
+    double score0;
+    double score1;
     if (logisticBounds_ == false) {
         score0       = neloToScoreWDL(elo0_, stdDeviation);
         score1       = neloToScoreWDL(elo1_, stdDeviation);
@@ -87,8 +87,8 @@ double SPRT::getLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int 
     if (var_penta == 0) return 0.0;
     const double stdDeviation_penta = std::sqrt(var_penta);
     const double var_s_penta        = var_penta / pairs;
-    const double score0;
-    const double score1;
+    double score0;
+    double score1;
     if (logisticBounds_ == false) {
         score0       = neloToScorePenta(elo0_, stdDeviation_penta);
         score1       = neloToScorePenta(elo1_, stdDeviation_penta);

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -49,13 +49,15 @@ double SPRT::getLLR(int win, int draw, int loss) const noexcept {
     if (var == 0) return 0.0;
     const double stdDeviation = std::sqrt(var);
     const double var_s        = var / games;
+    const double score0;
+    const double score1;
     if (logisticBounds_ == false) {
-        const double score0       = neloToScoreWDL(elo0_, stdDeviation);
-        const double score1       = neloToScoreWDL(elo1_, stdDeviation);
+        score0       = neloToScoreWDL(elo0_, stdDeviation);
+        score1       = neloToScoreWDL(elo1_, stdDeviation);
     }
     else if (logisticBounds_ == true) {
-        const double score0       = leloToScore(elo0_, stdDeviation);
-        const double score1       = leloToScore(elo1_, stdDeviation);
+        score0       = leloToScore(elo0_);
+        score1       = leloToScore(elo1_);
     }
     else {
         return 0.0;
@@ -87,11 +89,11 @@ double SPRT::getLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int 
     const double var_s_penta        = var_penta / pairs;
     const double score0;
     const double score1;
-    if (bounds == "normalized") {
+    if (logisticBounds_ == false) {
         score0       = neloToScorePenta(elo0_, stdDeviation_penta);
         score1       = neloToScorePenta(elo1_, stdDeviation_penta);
     }
-    else if (bounds== "logistic") {
+    else if (logisticBounds_ == true) {
         score0       = leloToScore(elo0_);
         score1       = leloToScore(elo1_);
     }

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -8,7 +8,7 @@
 
 namespace fast_chess {
 
-SPRT::SPRT(double alpha, double beta, double elo0, double elo1) {
+SPRT::SPRT(double alpha, double beta, double elo0, double elo1, bool bounds) {
     valid_ = alpha != 0.0 && beta != 0.0 && elo0 < elo1;
     if (isValid()) {
         lower_ = std::log(beta / (1 - alpha));
@@ -17,6 +17,8 @@ SPRT::SPRT(double alpha, double beta, double elo0, double elo1) {
         elo0_ = elo0;
         elo1_ = elo1;
 
+        logisticBounds_ = bounds;
+        
         Logger::log<Logger::Level::INFO>("Initialized valid SPRT configuration.");
     } else if (!(alpha == 0.0 && beta == 0.0 && elo0 == 0.0 && elo1 == 0.0)) {
         Logger::log<Logger::Level::INFO>("No valid SPRT configuration was found!");
@@ -47,11 +49,11 @@ double SPRT::getLLR(int win, int draw, int loss) const noexcept {
     if (var == 0) return 0.0;
     const double stdDeviation = std::sqrt(var);
     const double var_s        = var / games;
-    if (bounds == "normalized") {
+    if (logisticBounds_ == false) {
         const double score0       = neloToScoreWDL(elo0_, stdDeviation);
         const double score1       = neloToScoreWDL(elo1_, stdDeviation);
     }
-    else if (bounds== "logistic") {
+    else if (logisticBounds_ == true) {
         const double score0       = leloToScore(elo0_, stdDeviation);
         const double score1       = leloToScore(elo1_, stdDeviation);
     }

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -85,13 +85,15 @@ double SPRT::getLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int 
     if (var_penta == 0) return 0.0;
     const double stdDeviation_penta = std::sqrt(var_penta);
     const double var_s_penta        = var_penta / pairs;
+    const double score0;
+    const double score1;
     if (bounds == "normalized") {
-        const double score0       = neloToScorePenta(elo0_, stdDeviation_penta);
-        const double score1       = neloToScorePenta(elo1_, stdDeviation_penta);
+        score0       = neloToScorePenta(elo0_, stdDeviation_penta);
+        score1       = neloToScorePenta(elo1_, stdDeviation_penta);
     }
     else if (bounds== "logistic") {
-        const double score0       = leloToScore(elo0_, stdDeviation_penta);
-        const double score1       = leloToScore(elo1_, stdDeviation_penta);
+        score0       = leloToScore(elo0_);
+        score1       = leloToScore(elo1_);
     }
     else {
         return 0.0;

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -10,7 +10,7 @@ class SPRT {
    public:
     SPRT() = default;
 
-    SPRT(double alpha, double beta, double elo0, double elo1);
+    SPRT(double alpha, double beta, double elo0, double elo1, bool bounds);
 
     [[nodiscard]] bool isValid() const noexcept;
 

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -33,6 +33,7 @@ class SPRT {
     double elo1_ = 0.0;
 
     bool valid_ = false;
+    bool logisticBounds_ = false;
 };
 
 }  // namespace fast_chess

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -14,6 +14,7 @@ class SPRT {
 
     [[nodiscard]] bool isValid() const noexcept;
 
+    [[nodiscard]] static double leloToScore(double lelo) noexcept;
     [[nodiscard]] static double neloToScoreWDL(double nelo, double stdDeviation) noexcept;
     [[nodiscard]] static double neloToScorePenta(double nelo, double stdDeviation) noexcept;
     [[nodiscard]] double getLLR(int win, int draw, int loss) const noexcept;

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -15,7 +15,7 @@ RoundRobin::RoundRobin(const options::Tournament& tournament_config,
     : BaseTournament(tournament_config, engine_configs) {
     // Initialize the SPRT test
     sprt_ = SPRT(tournament_options_.sprt.alpha, tournament_options_.sprt.beta,
-                 tournament_options_.sprt.elo0, tournament_options_.sprt.elo1);
+                 tournament_options_.sprt.elo0, tournament_options_.sprt.elo1, tournament_options_.sprt.bounds);
 }
 
 void RoundRobin::start() {

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -33,7 +33,7 @@ struct Sprt {
     double elo1  = 0.0;
     bool bounds = false;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Sprt, alpha, beta, elo0, elo1)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Sprt, alpha, beta, elo0, elo1, bounds)
 
 struct DrawAdjudication {
     int move_number = 0;

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -31,7 +31,7 @@ struct Sprt {
     double beta  = 0.0;
     double elo0  = 0.0;
     double elo1  = 0.0;
-    bool bounds = true;
+    bool bounds = false;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Sprt, alpha, beta, elo0, elo1)
 

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -31,6 +31,7 @@ struct Sprt {
     double beta  = 0.0;
     double elo0  = 0.0;
     double elo1  = 0.0;
+    bool bounds = true;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Sprt, alpha, beta, elo0, elo1)
 


### PR DESCRIPTION
since we're now using normalized elo bounds for sprt to be similar to fishtest and openbench, i wanted to add the option for users to instead use logistic elo bounds if they prefer that more. so we can add a parameter to the options to specify if they want to use normalized or logistic bounds like this:
```-sprt elo0=ELO0 elo1=ELO1 alpha=ALPHA beta=BETA bounds=(logistic/normalized)```
unfortunately idk how the options and parsing code in cli.cpp works, maybe you can help me out? @Disservin 