### PR TITLE
fix bug in fastchess output when report_penta=false

### DIFF
--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -136,6 +136,7 @@ class Fastchess : public IOutput {
            std::stringstream ss;
            ss << "";
         }
+        std::stringstream ss;
         std::cout << ss.str() << std::flush;
     }
 

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -20,7 +20,7 @@ class Fastchess : public IOutput {
 
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
                   std::size_t current_game_count) override {
-        options::Tournament tournament
+        options::Tournament tournament;
         if (tournament.report_penta == true){
            const Elo elo(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
                          stats.penta_LD, stats.penta_LL);
@@ -98,7 +98,7 @@ class Fastchess : public IOutput {
 
     void printSprt(const SPRT& sprt, const Stats& stats) override {
         if (sprt.isValid()) {
-            options::Tournament tournament
+            options::Tournament tournament;
             if(tournament.report_penta == true) {
                std::stringstream ss;
    
@@ -119,7 +119,7 @@ class Fastchess : public IOutput {
     };
 
     static void printPenta(const Stats& stats) {
-        options::tournament tournament
+        options::tournament tournament;
         if (tournament.report_penta == true){
            std::stringstream ss;
    

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -19,73 +19,121 @@ class Fastchess : public IOutput {
 
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
                   std::size_t current_game_count) override {
-        const Elo elo(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
-                      stats.penta_LD, stats.penta_LL);
-
-        std::stringstream ss;
-        ss << "Score of "   //
-           << first         //
-           << " vs "        //
-           << second        //
-           << ": "          //
-           << stats.wins    //
-           << "W - "        //
-           << stats.losses  //
-           << "L - "        //
-           << stats.draws   //
-           << "D ["         //
-           << Elo::getScoreRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
-                                 stats.penta_LD, stats.penta_LL)  //
-           << "] "                                                //
-           << current_game_count                                  //
-           << "\n";
-
-        ss << "Elo difference: "   //
-           << elo.getElo()         //
-           << ", "                 //
-           << "nElo difference: "  //
-           << elo.getnElo()        //
-           << ", "                 //
-           << "LOS: "              //
-           << Elo::getLos(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
-                          stats.penta_LD, stats.penta_LL)  //
-           << ", "                                         //
-           << "PairDrawRatio: "                            //
-           << Elo::getDrawRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
-                                stats.penta_LD, stats.penta_LL)  //
-           << "\n";
-
-        std::cout << ss.str() << std::flush;
+        if (report_penta == true){
+           const Elo elo(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
+                         stats.penta_LD, stats.penta_LL);
+   
+           std::stringstream ss;
+           ss << "Score of "   //
+              << first         //
+              << " vs "        //
+              << second        //
+              << ": "          //
+              << stats.wins    //
+              << "W - "        //
+              << stats.losses  //
+              << "L - "        //
+              << stats.draws   //
+              << "D ["         //
+              << Elo::getScoreRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
+                                    stats.penta_LD, stats.penta_LL)  //
+              << "] "                                                //
+              << current_game_count                                  //
+              << "\n";
+   
+           ss << "Elo difference: "   //
+              << elo.getElo()         //
+              << ", "                 //
+              << "nElo difference: "  //
+              << elo.getnElo()        //
+              << ", "                 //
+              << "LOS: "              //
+              << Elo::getLos(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
+                             stats.penta_LD, stats.penta_LL)  //
+              << ", "                                         //
+              << "PairDrawRatio: "                            //
+              << Elo::getDrawRatio(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
+                                   stats.penta_LD, stats.penta_LL)  //
+              << "\n";
+   
+           std::cout << ss.str() << std::flush;
+        } else {
+           const Elo elo(stats.wins, stats.losses, stats.draws);
+   
+           std::stringstream ss;
+           ss << "Score of "   //
+              << first         //
+              << " vs "        //
+              << second        //
+              << ": "          //
+              << stats.wins    //
+              << "W - "        //
+              << stats.losses  //
+              << "L - "        //
+              << stats.draws   //
+              << "D ["         //
+              << Elo::getScoreRatio(stats.wins, stats.losses, stats.draws)  //
+              << "] "                                                //
+              << current_game_count                                  //
+              << "\n";
+   
+           ss << "Elo difference: "   //
+              << elo.getElo()         //
+              << ", "                 //
+              << "nElo difference: "  //
+              << elo.getnElo()        //
+              << ", "                 //
+              << "LOS: "              //
+              << Elo::getLos(stats.wins, stats.losses, stats.draws)  //
+              << ", "                                         //
+              << "DrawRatio: "                            //
+              << Elo::getDrawRatio(stats.wins, stats.losses, stats.draws)  //
+              << "\n";
+   
+           std::cout << ss.str() << std::flush;
+        }
     }
 
     void printSprt(const SPRT& sprt, const Stats& stats) override {
         if (sprt.isValid()) {
-            std::stringstream ss;
-
-            ss << "LLR: " << std::fixed << std::setprecision(2)
-               << sprt.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
-                              stats.penta_LD, stats.penta_LL)
-               << " " << sprt.getBounds() << " " << sprt.getElo() << "\n";
-            std::cout << ss.str() << std::flush;
+            if(report_penta == true) {
+               std::stringstream ss;
+   
+               ss << "LLR: " << std::fixed << std::setprecision(2)
+                  << sprt.getLLR(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
+                                 stats.penta_LD, stats.penta_LL)
+                  << " " << sprt.getBounds() << " " << sprt.getElo() << "\n";
+               std::cout << ss.str() << std::flush;
+            } else {
+               std::stringstream ss;
+   
+               ss << "LLR: " << std::fixed << std::setprecision(2)
+                  << sprt.getLLR(stats.wins, stats.losses, stats.draws)
+                  << " " << sprt.getBounds() << " " << sprt.getElo() << "\n";
+               std::cout << ss.str() << std::flush;
+            }
         }
     };
 
     static void printPenta(const Stats& stats) {
-        std::stringstream ss;
-
-        ss << "Ptnml:   " << std::right << std::setw(7)  //
-           << "LL" << std::right << std::setw(7)         //
-           << "LD" << std::right << std::setw(7)         //
-           << "DD/WL" << std::right << std::setw(7)      //
-           << "WD" << std::right << std::setw(7)         //
-           << "WW"
-           << "\n"
-           << "Distr:   " << std::right << std::setw(7)                      //
-           << stats.penta_LL << std::right << std::setw(7)                   //
-           << stats.penta_LD << std::right << std::setw(7)                   //
-           << stats.penta_WL + stats.penta_DD << std::right << std::setw(7)  //
-           << stats.penta_WD << std::right << std::setw(7)                   //
-           << stats.penta_WW << "\n";
+        if (report_penta == true){
+           std::stringstream ss;
+   
+           ss << "Ptnml:   " << std::right << std::setw(7)  //
+              << "LL" << std::right << std::setw(7)         //
+              << "LD" << std::right << std::setw(7)         //
+              << "DD/WL" << std::right << std::setw(7)      //
+              << "WD" << std::right << std::setw(7)         //
+              << "WW"
+              << "\n"
+              << "Distr:   " << std::right << std::setw(7)                      //
+              << stats.penta_LL << std::right << std::setw(7)                   //
+              << stats.penta_LD << std::right << std::setw(7)                   //
+              << stats.penta_WL + stats.penta_DD << std::right << std::setw(7)  //
+              << stats.penta_WD << std::right << std::setw(7)                   //
+              << stats.penta_WW << "\n";
+        }
+        else ss << "";
         std::cout << ss.str() << std::flush;
     }
 

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -119,7 +119,7 @@ class Fastchess : public IOutput {
     };
 
     static void printPenta(const Stats& stats) {
-        options::tournament tournament;
+        options::Tournament tournament;
         if (tournament.report_penta == true){
            std::stringstream ss;
    

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -19,7 +19,8 @@ class Fastchess : public IOutput {
 
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
                   std::size_t current_game_count) override {
-        if (report_penta == true){
+        options::Tournament tournament
+        if (tournament.report_penta == true){
            const Elo elo(stats.penta_WW, stats.penta_WD, stats.penta_WL, stats.penta_DD,
                          stats.penta_LD, stats.penta_LL);
    
@@ -96,7 +97,8 @@ class Fastchess : public IOutput {
 
     void printSprt(const SPRT& sprt, const Stats& stats) override {
         if (sprt.isValid()) {
-            if(report_penta == true) {
+            options::Tournament tournament
+            if(tournament.report_penta == true) {
                std::stringstream ss;
    
                ss << "LLR: " << std::fixed << std::setprecision(2)
@@ -116,7 +118,8 @@ class Fastchess : public IOutput {
     };
 
     static void printPenta(const Stats& stats) {
-        if (report_penta == true){
+        options::tournament tournament
+        if (tournament.report_penta == true){
            std::stringstream ss;
    
            ss << "Ptnml:   " << std::right << std::setw(7)  //

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -3,6 +3,7 @@
 #include <matchmaking/elo/elo.hpp>
 #include <matchmaking/output/output.hpp>
 #include <util/logger/logger.hpp>
+#include <types/tournament_options.hpp>
 
 namespace fast_chess {
 

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -132,8 +132,10 @@ class Fastchess : public IOutput {
               << stats.penta_WL + stats.penta_DD << std::right << std::setw(7)  //
               << stats.penta_WD << std::right << std::setw(7)                   //
               << stats.penta_WW << "\n";
+        } else {
+           std::stringstream ss;
+           ss << "";
         }
-        else ss << "";
         std::cout << ss.str() << std::flush;
     }
 


### PR DESCRIPTION
output:
![Screenshot 2024-04-13 162652](https://github.com/Disservin/fast-chess/assets/155860115/7b790da9-822d-49b1-abda-fc8b389c7892)
This is caused by fastchess output still displaying penta stats when penta option is set to false. the fix for this is to display trinomial stats instead when report penta is false. ive added the report_penta conditional in output_fastchess.cpp but idk which header i should include so i can use the boolean, can you help?

Edit: found it