### PR TITLE
True EPD implementation

### DIFF
--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -49,7 +49,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         openingFile.close();
         
         std::vector<std::pair<std::string, std::pair<int, int>>> fenData;
-    
+        
         for (const auto& line : epd) {
             // Find the position of the first semicolon
             size_t pos = line.find(';');
@@ -65,34 +65,36 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
                     }
                 }
             }
-    
+        
             // Extract first four FEN fields
             std::string first_four_fen = line.substr(0, posspace);
-    
+        
             // Default values for hmvc and fmvn
             int hmvc = 0;
             int fmvn = 1;
-    
-            // Extract hmvc and fmvn values from the remaining parts
+        
+            // Extract hmvc and fmvn values before the first semicolon
             if (pos != std::string::npos) {
-                auto parts = split(line.substr(pos + 1), ';');
-                for (const auto& part : parts) {
+                std::istringstream iss(line.substr(pos + 1));  // Start from after the first semicolon
+                std::string part;
+                while (std::getline(iss, part, ';')) {
                     if (part.find("hmvc") != std::string::npos) {
-                        std::istringstream iss(part.substr(part.find("hmvc") + 4));
-                        iss >> hmvc; // Reading the integer value after "hmvc"
-                    } else if (part.find("fmvn") != std::string::npos) {
-                        std::istringstream iss(part.substr(part.find("fmvn") + 4));
-                        iss >> fmvn; // Reading the integer value after "fmvn"
+                        std::istringstream part_iss(part.substr(part.find("hmvc") + 4));
+                        part_iss >> hmvc; // Reading the integer value after "hmvc"
+                    }
+                    if (part.find("fmvn") != std::string::npos) {
+                        std::istringstream part_iss(part.substr(part.find("fmvn") + 4));
+                        part_iss >> fmvn; // Reading the integer value after "fmvn"
                     }
                 }
             }
-    
+        
             // Store in the vector
             fenData.push_back({first_four_fen, {hmvc, fmvn}});
         }
-    
+        
         std::vector<std::string> fen;
-    
+        
         for (const auto& data : fenData) {
             std::ostringstream oss;
             oss << data.first << " " << data.second.first << " " << data.second.second;

--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -79,7 +79,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
                     if (part.find("hmvc") != std::string::npos) {
                         std::istringstream iss(part.substr(part.find("hmvc") + 4));
                         iss >> hmvc; // Reading the integer value after "hmvc"
-                    } else if (part.find("fmvn") != std::string::npos) {
+                    }
+                    if (part.find("fmvn") != std::string::npos) {
                         std::istringstream iss(part.substr(part.find("fmvn") + 4));
                         iss >> fmvn; // Reading the integer value after "fmvn"
                     }

--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -74,18 +74,26 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
             int fmvn = 1;
         
             // Extract hmvc and fmvn values before the first semicolon
+            std::string before_semicolon = line.substr(0, pos);
+            if (before_semicolon.find("hmvc") != std::string::npos) {
+                std::istringstream iss(before_semicolon.substr(before_semicolon.find("hmvc") + 4));
+                iss >> hmvc; // Reading the integer value after "hmvc"
+            }
+            if (before_semicolon.find("fmvn") != std::string::npos) {
+                std::istringstream iss(before_semicolon.substr(before_semicolon.find("fmvn") + 4));
+                iss >> fmvn; // Reading the integer value after "fmvn"
+            }
+        
+            // Extract hmvc and fmvn values after the first semicolon
             if (pos != std::string::npos) {
-                std::istringstream iss(line.substr(pos + 1));  // Start from after the first semicolon
-                std::string part;
-                while (std::getline(iss, part, ';')) {
-                    if (part.find("hmvc") != std::string::npos) {
-                        std::istringstream part_iss(part.substr(part.find("hmvc") + 4));
-                        part_iss >> hmvc; // Reading the integer value after "hmvc"
-                    }
-                    if (part.find("fmvn") != std::string::npos) {
-                        std::istringstream part_iss(part.substr(part.find("fmvn") + 4));
-                        part_iss >> fmvn; // Reading the integer value after "fmvn"
-                    }
+                std::string after_semicolon = line.substr(pos + 1);
+                if (after_semicolon.find("hmvc") != std::string::npos) {
+                    std::istringstream iss(after_semicolon.substr(after_semicolon.find("hmvc") + 4));
+                    iss >> hmvc; // Reading the integer value after "hmvc"
+                }
+                if (after_semicolon.find("fmvn") != std::string::npos) {
+                    std::istringstream iss(after_semicolon.substr(after_semicolon.find("fmvn") + 4));
+                    iss >> fmvn; // Reading the integer value after "fmvn"
                 }
             }
         

--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -70,16 +70,21 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
             std::string first_four_fen = line.substr(0, posspace);
     
             // Default values for hmvc and fmvn
-            int hmvc = 0, fmvn = 1;
+            int hmvc = 0;
+            int fmvn = 1;
     
             // Extract hmvc and fmvn values from the remaining parts
-            auto parts = split(line.substr(pos + 1), ';');
-            for (const auto& part : parts) {
-                    std::istringstream iss(part.substr(part.find("hmvc") + 4));
-                    iss >> hmvc; // Reading the integer value after "hmvc"
-                    
-                    std::istringstream iss(part.substr(part.find("fmvn") + 4));
-                    iss >> fmvn; // Reading the integer value after "fmvn"
+            if (pos != std::string::npos) {
+                auto parts = split(line.substr(pos + 1), ';');
+                for (const auto& part : parts) {
+                    if (part.find("hmvc") != std::string::npos) {
+                        std::istringstream iss(part.substr(part.find("hmvc") + 4));
+                        iss >> hmvc; // Reading the integer value after "hmvc"
+                    } else if (part.find("fmvn") != std::string::npos) {
+                        std::istringstream iss(part.substr(part.find("fmvn") + 4));
+                        iss >> fmvn; // Reading the integer value after "fmvn"
+                    }
+                }
             }
     
             // Store in the vector

--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -1,6 +1,7 @@
 #include <matchmaking/book/opening_book.hpp>
 
 #include <fstream>
+#include <sstream>
 #include <string>
 
 #include <util/safe_getline.hpp>
@@ -10,6 +11,17 @@ namespace fast_chess {
 OpeningBook::OpeningBook(const options::Opening& opening) {
     start_ = opening.start;
     setup(opening.file, opening.format);
+}
+
+// Function to split a string by space
+std::vector<std::string> split(const std::string& s, char delimiter) {
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream tokenStream(s);
+    while (std::getline(tokenStream, token, delimiter)) {
+        tokens.push_back(token);
+    }
+    return tokens;
 }
 
 void OpeningBook::setup(const std::string& file, FormatType type) {

--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -70,22 +70,17 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
             std::string first_four_fen = line.substr(0, posspace);
     
             // Default values for hmvc and fmvn
-            int hmvc = 0;
-            int fmvn = 1;
+            int hmvc = 0, fmvn = 1;
     
             // Extract hmvc and fmvn values from the remaining parts
-            if (pos != std::string::npos) {
-                auto parts = split(line.substr(pos + 1), ';');
-                for (const auto& part : parts) {
-                    if (part.find("hmvc") != std::string::npos) {
-                        std::istringstream iss(part.substr(part.find("hmvc") + 4));
-                        iss >> hmvc; // Reading the integer value after "hmvc"
-                    }
-                    if (part.find("fmvn") != std::string::npos) {
-                        std::istringstream iss(part.substr(part.find("fmvn") + 4));
-                        iss >> fmvn; // Reading the integer value after "fmvn"
-                    }
-                }
+
+            auto parts = split(line.substr(pos + 1), ';');
+            for (const auto& part : parts) {
+                    std::istringstream iss(part.substr(part.find("hmvc") + 4));
+                    iss >> hmvc; // Reading the integer value after "hmvc"
+                    
+                    std::istringstream iss(part.substr(part.find("fmvn") + 4));
+                    iss >> fmvn; // Reading the integer value after "fmvn"
             }
     
             // Store in the vector

--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -73,7 +73,6 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
             int hmvc = 0, fmvn = 1;
     
             // Extract hmvc and fmvn values from the remaining parts
-
             auto parts = split(line.substr(pos + 1), ';');
             for (const auto& part : parts) {
                     std::istringstream iss(part.substr(part.find("hmvc") + 4));

--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -56,7 +56,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
             
             // Find the position of the 4th space
             size_t posspace = std::string::npos;
-            for (int i = 0, spaceCount = 0; i < line.size(); ++i) {
+            for (std::string::size_type i = 0, spaceCount = 0; i < line.size(); ++i) {
                 if (line[i] == ' ') {
                     ++spaceCount;
                     if (spaceCount == 4) {

--- a/src/matchmaking/book/opening_book.cpp
+++ b/src/matchmaking/book/opening_book.cpp
@@ -70,7 +70,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
             std::string first_four_fen = line.substr(0, posspace);
     
             // Default values for hmvc and fmvn
-            int hmvc = 0, fmvn = 1;
+            int hmvc = 0;
+            int fmvn = 1;
     
             // Extract hmvc and fmvn values from the remaining parts
             if (pos != std::string::npos) {

--- a/tests/data/openings.epd
+++ b/tests/data/openings.epd
@@ -1,100 +1,100 @@
-r1bqkb1r/pp3pp1/2nppn2/7p/3NP1PP/2N5/PPP2P2/R1BQKBR1 w Qkq - 0 9
-rnb2rk1/ppp2pbp/3p2p1/3Pp2n/2P1P2q/2N1BP2/PP1Q2PP/R3KBNR w KQ - 3 9
-r3kb1r/pppqpppp/1nn1b3/4P3/3P4/2NBB3/PP3PPP/R2QK1NR w KQkq - 7 9
-r1bqk2r/pp2bpp1/2nppn1p/8/3NP1PP/2N1B3/PPP2P2/R2QKB1R w KQkq - 3 9
-rn1qkb1r/4pp1p/3p1np1/2pP4/4P3/2N5/PP3PPP/R1BQ1KNR w kq - 0 9
-rnb1qrk1/1pp2pbp/3p1np1/p2Pp3/2P1P3/2N2N1P/PP2BPP1/R1BQK2R w KQ - 1 9
-r2qkb1r/pp3ppp/n1p1pn2/7b/P1BP4/2N1PN1P/1P3PP1/R1BQK2R w KQkq - 1 9
-r1b1k1nr/pp1nqppp/2p5/4p1bQ/2B1P3/8/PPP2PPP/RNB2RK1 w kq - 2 9
-rnbq1rk1/ppp1ppbp/1n4p1/8/2BP4/2N1PN2/PP2QPPP/R1B2RK1 w - - 7 9
-rnbqk2r/1p3pbp/p2p1np1/2pP4/4P3/2N2N1P/PP3PP1/R1BQKB1R w KQkq - 1 9
-rnbq1rk1/pppp2bp/4p1p1/5p2/3PP3/3B1N2/PPPNQPPP/R3K2R w KQ - 2 9
-rn1q1rk1/pppbppbp/6p1/4P3/2Q3n1/2N2N2/PP1P1PPP/R1B1KB1R w KQ - 1 9
-r1bqk2r/pppn2bp/5ppn/4p3/1PPp4/3P1NP1/P2NPPBP/R1BQ1RK1 w kq - 0 9
-r3k2r/pppqnppp/2nbp3/3p4/2PP4/2N1PPB1/PP3P1P/R2QKB1R w KQkq - 1 9
-r2qkb1r/1p2pppp/p1bp1n2/8/3NP3/8/PPP2PPP/RNBQR1K1 w kq - 1 9
-r1b1kbnr/p4ppp/2p1p3/3q4/2p5/3P1N2/PPP2PPP/RNBQK2R w KQkq - 0 9
-rnb1kb1r/1p2qp1p/p2p1np1/2pP4/P7/2N2N1P/1P2PPP1/R1BQKB1R w KQkq - 1 9
-rn1qkb1r/ppp2ppp/5n2/3Pp3/2p1P3/2N1BP2/PP3P1P/R2QKB1R w KQkq - 1 9
-rn1qkb1r/1p1npppp/p1p3b1/3pN3/2PP2P1/4P2P/PP1N1P2/R1BQKB1R w KQkq - 3 9
-rnbqk1nr/5pbp/p2p2p1/1ppP4/4PB2/2N2N2/PP3PPP/R2QKB1R w KQkq b6 0 9
-r1b1kb1r/pp1n1p1p/1qn1p1p1/2ppP3/3P4/2PB1N2/PP1N1PPP/R1BQ1RK1 w kq - 0 9
-rnbq1k1r/pp3pbp/3p2pn/2pP4/2P5/5N1P/PP2QPP1/RNB1KB1R w KQ - 3 9
-rnbqk2r/pp1n1pbp/3p2p1/1BpP4/4PP2/2N5/PP4PP/R1BQK1NR w KQkq - 3 9
-r1b1kb1r/1pq2ppp/p1nppn2/8/3NPP2/2N1BQ2/PPP3PP/R3KB1R w KQkq - 2 9
-rnb2rk1/pp2nppp/4p3/q1ppP3/3P2Q1/P1PB4/2P2PPP/R1B1K1NR w KQ - 5 9
-rnb2rk1/pp2nppp/4p3/q1ppP3/3P2Q1/P1P5/2PB1PPP/R3KBNR w KQ - 5 9
-r1bq1rk1/pp3pbp/n2ppnp1/2pP4/2P1P3/2N2N2/PP2BPPP/R1BQ1RK1 w - - 2 9
-rnb1k2r/pp3pbp/2p2np1/q3p3/4P3/2NBBN2/PPP2PPP/R2Q1RK1 w kq - 0 9
-rn1qkb1r/pb3ppp/1p3n2/3p4/3pP3/P1N2N2/1PQ2PPP/R1B1KB1R w KQkq - 0 9
-1n1qkb1r/rp3ppp/p1p1pn2/2PpN2b/3PP3/1QN5/PP3PPP/R1B1KB1R w KQk - 0 9
-r1bq1rk1/ppp2pbp/2np2p1/4p2n/3P4/4PN1P/PPP1BPPB/RN1Q1RK1 w - e6 0 9
-rn1q1rk1/ppp1ppbp/6p1/3n4/3P4/2P2b1P/PP2BPP1/RNBQ1RK1 w - - 0 9
-r1bq1rk1/ppp1ppbp/5np1/3Pp3/2P1P3/2N4P/PP3PP1/R1BQKB1R w KQ - 2 9
-r1bq1rk1/pp3pbp/n2ppnp1/2pP4/2P1P3/2NB1N1P/PP3PP1/R1BQK2R w KQ - 2 9
-r1bqnrk1/pp1nbppp/3p4/2pPp3/2P1P3/2N3P1/PP2NPBP/R1BQK2R w KQ - 5 9
-r1b1qrk1/ppp2pbp/n2p1np1/4p3/2PP4/2N2NPP/PP2PPB1/R1BQ1RK1 w - e6 0 9
-rnb1k1nr/1pqpbp1p/p3p1p1/8/4P1Q1/1NNB4/PPP2PPP/R1B1K2R w KQkq - 0 9
-rnbqk3/pp2bpp1/3ppn2/7r/3NP3/2N1B3/PPP2P1P/R2QKB1R w KQq - 0 9
-rn1q1rk1/p2pbppp/bp3n2/2pp4/2P1P3/1QN2NP1/PP3P1P/R1B1KB1R w KQ - 0 9
-rnq1kb1r/pp2pp1p/2p1bnp1/8/2pPPN2/2N2P2/PP4PP/R1BQKB1R w KQkq - 0 9
-r1bq1rk1/pppnppbp/1n4p1/1B6/3PP3/2N1B3/PP3PPP/R2QK1NR w KQ - 5 9
-rnbqkb1r/5ppp/p2p1n2/2pP4/Pp2P3/5NP1/1P3P1P/RNBQKB1R w KQkq - 0 9
-rn1qkb1r/ppn1pppp/2p1b3/4N3/2PP2P1/8/PP2BP1P/RNBQK2R w KQkq - 1 9
-1rbqkb1r/p2n1ppp/2n1p3/1pppP3/3P1P2/2PB1N2/PP4PP/R1BQK1NR w KQk b6 0 9
-r1bq1rk1/pp1p1ppp/4pn2/4n3/1bPN4/2N3P1/PP2PPBP/R1BQ1RK1 w - - 7 9
-r1b1kb1r/3pnppp/pqn1p3/1p6/4P3/2NB1N2/PPP2PPP/R1BQ1RK1 w kq - 6 9
-rnbqk2r/pp2ppb1/2pp1npp/8/3PP2B/2N2P2/PPPQ2PP/R3KBNR w KQkq - 1 9
-rn1qk2r/pp1bbppp/5n2/1B1p4/3p4/5N2/PPPNQPPP/R1B2RK1 w kq - 2 9
-rnbqk2r/p1p2pp1/1p2p1n1/3pP2p/3P2QP/P1P5/2P2PP1/R1B1KBNR w KQkq h6 0 9
-r2qkb1r/pp2pppp/2p2n2/3n1b2/3P4/5N2/PPP1BPPP/RNBQ1RK1 w kq - 6 9
-r2qkb1r/pp2pppp/2p2n2/3n4/3P2b1/5N2/PPP1BPPP/RNBQ1RK1 w kq - 6 9
-rn1qkb1r/4pp1p/p1p2n2/1pPp1p2/3P4/2N1PN2/PP3PPP/R1BQK2R w KQkq - 0 9
-rn1qk2r/ppp1ppbp/1n2b1p1/8/3P4/2N2N2/PPQ1PPPP/R1B1KB1R w KQkq - 3 9
-r2qkb1r/1p1bnppp/p3p3/2p5/4PB2/2N2N2/PPP2PPP/R2QK2R w KQkq - 2 9
-r1bqkb1r/3p1ppp/p1p1p3/3nP3/8/2N5/PPP1BPPP/R1BQK2R w KQkq - 1 9
-r1b1kb1r/1p2pppp/p1np4/q5B1/3NP1n1/2N4P/PPP2PP1/R2QKB1R w KQkq - 1 9
-r1bqkb1r/1p3ppp/p1np1n2/4p3/3NPP2/2N1BQ2/PPP3PP/R3KB1R w KQkq - 0 9
-rnbq1rk1/pp2b1pp/3p1n2/2pP1p2/2P1p3/2N3PN/PP2PPBP/R1BQ1RK1 w - c6 0 9
-rnbq1rk1/1p3pbp/p2ppnp1/2pP4/P1P1P3/2N2N1P/1P3PP1/R1BQKB1R w KQ - 0 9
-rnbq1rk1/pp2ppbp/2p3p1/5n2/3PNB2/2P2N1P/PP3PP1/R2QKB1R w KQ - 1 9
-r2qkb1r/pp1nn1pp/2p1p3/3ppb2/3P4/1N3N2/PPP1BPPP/R1BQ1RK1 w kq - 0 9
-r1bq1rk1/ppp1bppp/2n1pn2/2Pp4/Q2P4/P1N1PN2/1P3PPP/R1B1KB1R w KQ - 1 9
-r1bq1rk1/1p1nppbp/p1p2np1/3p4/2PP1B2/2N1PN1P/PP2BPP1/R2QK2R w KQ - 2 9
-rnbq1rk1/ppb2ppp/3p1n2/2pP2B1/8/2N1PN2/PP3PPP/R2QKB1R w KQ - 1 9
-r1bq1rk1/pp3pbp/n2ppnp1/2pP2B1/2P1P3/2N5/PP1QBPPP/R3K1NR w KQ - 0 9
-r1bqk1nr/1p1p1ppp/p1n1pb2/8/4P3/1N1B2Q1/PPP2PPP/RNB1K2R w KQkq - 8 9
-r2qk2r/pbpnnpbp/1p1pp1p1/8/3PP3/2PB1N2/PP1N1PPP/R1BQR1K1 w kq - 4 9
-rn1qkb1r/1p3p1p/p2p1np1/2pP4/4P1b1/2N2N2/PP2QPPP/R1B1KB1R w KQkq - 2 9
-r2qkb1r/pbp1nppp/1p1pp3/8/2PPP3/2NQ4/PP2NPPP/R1B2RK1 w kq - 0 9
-rn1qkb1r/1p3ppp/2bp1n2/p3p3/4P3/1NN1BP2/PPP3PP/R2QKB1R w KQkq a6 0 9
-r1b1k2r/1p1p1ppp/p1n1pn2/q7/1bPNP3/2N2Q2/PP1B1PPP/R3KB1R w KQkq - 7 9
-rnb1kb1r/p3pppp/3n4/qppP4/P1p2B2/2N5/1P2NPPP/R2QKB1R w KQkq - 2 9
-r2qk2r/pb1pppbp/1pn2np1/8/2PNP3/2N1BP2/PP4PP/R2QKB1R w KQkq - 2 9
-rnbq1rk1/2p2pbp/pp1ppnp1/8/P2PP3/2N2N2/1PP1BPPP/R1BQR1K1 w - - 0 9
-rnbqrbk1/pp1p1ppp/5n2/2pP2B1/8/2N1PN2/PP3PPP/R2QKB1R w KQ - 1 9
-rn1q1rk1/pp1nppbp/3p2p1/2p5/2PPP1b1/2N1BN2/PP2BPPP/2RQK2R w K c6 0 9
-r1bqk1nr/2pp1pbp/p1n3p1/8/R2pP3/1B3N2/1PP2PPP/1NBQK2R w Kkq - 1 9
-r1bqkb1r/5ppp/p1pppn2/6B1/4PP2/2N5/PPP3PP/R2QKB1R w KQkq - 0 9
-1rbq1rk1/pp2ppbp/n2p1np1/2pP4/4PP2/2NB1N2/PPP3PP/R1BQ1RK1 w - - 1 9
-r1bqk2r/pp2ppbp/3p2pn/8/2BpP3/5Q2/PPPPNPPP/R1B1K2R w KQkq - 0 9
-rnbq1rk1/pp2ppbp/1n4p1/2p5/3PP3/6P1/PP2NPBP/RNBQ1RK1 w - c6 0 9
-r1b1k1nr/2p1qppp/p1p5/2bpp3/8/1P2PN2/PB1P1PPP/RN1QK2R w KQkq - 0 9
-r2qkb1r/ppp2ppp/2n5/3p4/3P2b1/2PB1N2/P1P2PPP/R1BQK2R w KQkq - 1 9
-r1bqk2r/1ppn1ppp/3ppn2/6B1/p1PP4/P3PN2/1P3PPP/R2QKB1R w KQkq - 1 9
-rn1qk2r/p2nbppp/bp2p3/2ppP3/3P4/2PB4/PP1NNPPP/R1BQ1RK1 w kq - 2 9
-r1b1kbnr/pp1nq3/2pp1pp1/4p2p/2PPP2B/2N2N2/PP2BPPP/R2QK2R w KQkq h6 0 9
-rnbqk2r/p3ppbp/3p1np1/2pP4/2P1P3/R1N5/1PQ2PPP/2B1KBNR w Kkq - 2 9
-rnbqk2r/pp2p1bp/2pp1np1/5P2/3P4/2N3P1/PPP2PB1/R1BQK1NR w KQkq - 3 9
-r1bqkb1r/pp3ppp/1nn1p3/3pP3/3P4/3B4/PP1NNPPP/R1BQK2R w KQkq - 1 9
-r3kb1r/pp1n1ppp/2p1pn2/q7/2PP2b1/2N2N2/PP2BPPP/R1BQ1RK1 w kq - 2 9
-r2qkb1r/pp1b1pp1/n1p1pn1p/3p4/3P1B2/P1NBPP2/1PP1N1PP/R2QK2R w KQkq - 0 9
-r1bq1rk1/pp2ppbp/2n3pn/3pP3/3P4/2N2N1P/PP3PP1/R1BQKB1R w KQ - 3 9
-rn1qk2r/ppp1npbp/3p2p1/3P4/8/2N2PP1/PP3P1P/R1BQKB1R w KQkq - 1 9
-rnbqr1k1/pp1p1pp1/3b1n1p/2pP4/7B/2N2N2/PP2PPPP/R2QKB1R w KQ - 4 9
-r1b1k1nr/ppq3pp/2n1p3/2ppPp2/3P4/P1P3Q1/2P2PPP/R1B1KBNR w KQkq - 2 9
-r1bqk1nr/1ppp2bp/2n3p1/5p2/1PP1p3/2N3P1/3PPPBP/1RBQK1NR w Kkq - 0 9
-r1bqk2r/1p1nppb1/p2p1npp/2pP4/P1B1P3/2N2N2/1PP2PPP/R1BQK2R w KQkq - 0 9
-rnbq1rk1/ppp3b1/3ppnpp/5p2/2PP4/1P3NP1/PB2PPBP/RN1Q1RK1 w - - 0 9
-r1bq1rk1/ppn1ppbp/3p1np1/2pP4/4PP2/2NB1N2/PPP3PP/R1BQ1RK1 w - - 1 9
-r1bqk2r/ppp2ppp/2nn4/1Bb5/3p4/2P2N2/PP3PPP/RNBQ1RK1 w kq - 0 9
+r1bqkb1r/pp3pp1/2nppn2/7p/3NP1PP/2N5/PPP2P2/R1BQKBR1 w Qkq - hmvc 0; fmvn 9;
+rnb2rk1/ppp2pbp/3p2p1/3Pp2n/2P1P2q/2N1BP2/PP1Q2PP/R3KBNR w KQ - hmvc 3; fmvn 9;
+r3kb1r/pppqpppp/1nn1b3/4P3/3P4/2NBB3/PP3PPP/R2QK1NR w KQkq - hmvc 7; fmvn 9;
+r1bqk2r/pp2bpp1/2nppn1p/8/3NP1PP/2N1B3/PPP2P2/R2QKB1R w KQkq - hmvc 3; fmvn 9;
+rn1qkb1r/4pp1p/3p1np1/2pP4/4P3/2N5/PP3PPP/R1BQ1KNR w kq - hmvc 0; fmvn 9;
+rnb1qrk1/1pp2pbp/3p1np1/p2Pp3/2P1P3/2N2N1P/PP2BPP1/R1BQK2R w KQ - hmvc 1; fmvn 9;
+r2qkb1r/pp3ppp/n1p1pn2/7b/P1BP4/2N1PN1P/1P3PP1/R1BQK2R w KQkq - hmvc 1; fmvn 9;
+r1b1k1nr/pp1nqppp/2p5/4p1bQ/2B1P3/8/PPP2PPP/RNB2RK1 w kq - hmvc 2; fmvn 9;
+rnbq1rk1/ppp1ppbp/1n4p1/8/2BP4/2N1PN2/PP2QPPP/R1B2RK1 w - - hmvc 7; fmvn 9;
+rnbqk2r/1p3pbp/p2p1np1/2pP4/4P3/2N2N1P/PP3PP1/R1BQKB1R w KQkq - hmvc 1; fmvn 9;
+rnbq1rk1/pppp2bp/4p1p1/5p2/3PP3/3B1N2/PPPNQPPP/R3K2R w KQ - hmvc 2; fmvn 9;
+rn1q1rk1/pppbppbp/6p1/4P3/2Q3n1/2N2N2/PP1P1PPP/R1B1KB1R w KQ - hmvc 1; fmvn 9;
+r1bqk2r/pppn2bp/5ppn/4p3/1PPp4/3P1NP1/P2NPPBP/R1BQ1RK1 w kq - hmvc 0; fmvn 9;
+r3k2r/pppqnppp/2nbp3/3p4/2PP4/2N1PPB1/PP3P1P/R2QKB1R w KQkq - hmvc 1; fmvn 9;
+r2qkb1r/1p2pppp/p1bp1n2/8/3NP3/8/PPP2PPP/RNBQR1K1 w kq - hmvc 1; fmvn 9;
+r1b1kbnr/p4ppp/2p1p3/3q4/2p5/3P1N2/PPP2PPP/RNBQK2R w KQkq - hmvc 0; fmvn 9;
+rnb1kb1r/1p2qp1p/p2p1np1/2pP4/P7/2N2N1P/1P2PPP1/R1BQKB1R w KQkq - hmvc 1; fmvn 9;
+rn1qkb1r/ppp2ppp/5n2/3Pp3/2p1P3/2N1BP2/PP3P1P/R2QKB1R w KQkq - hmvc 1; fmvn 9;
+rn1qkb1r/1p1npppp/p1p3b1/3pN3/2PP2P1/4P2P/PP1N1P2/R1BQKB1R w KQkq - hmvc 3; fmvn 9;
+rnbqk1nr/5pbp/p2p2p1/1ppP4/4PB2/2N2N2/PP3PPP/R2QKB1R w KQkq b6 hmvc 0; fmvn 9;
+r1b1kb1r/pp1n1p1p/1qn1p1p1/2ppP3/3P4/2PB1N2/PP1N1PPP/R1BQ1RK1 w kq - hmvc 0; fmvn 9;
+rnbq1k1r/pp3pbp/3p2pn/2pP4/2P5/5N1P/PP2QPP1/RNB1KB1R w KQ - hmvc 3; fmvn 9;
+rnbqk2r/pp1n1pbp/3p2p1/1BpP4/4PP2/2N5/PP4PP/R1BQK1NR w KQkq - hmvc 3; fmvn 9;
+r1b1kb1r/1pq2ppp/p1nppn2/8/3NPP2/2N1BQ2/PPP3PP/R3KB1R w KQkq - hmvc 2; fmvn 9;
+rnb2rk1/pp2nppp/4p3/q1ppP3/3P2Q1/P1PB4/2P2PPP/R1B1K1NR w KQ - hmvc 5; fmvn 9;
+rnb2rk1/pp2nppp/4p3/q1ppP3/3P2Q1/P1P5/2PB1PPP/R3KBNR w KQ - hmvc 5; fmvn 9;
+r1bq1rk1/pp3pbp/n2ppnp1/2pP4/2P1P3/2N2N2/PP2BPPP/R1BQ1RK1 w - - hmvc 2; fmvn 9;
+rnb1k2r/pp3pbp/2p2np1/q3p3/4P3/2NBBN2/PPP2PPP/R2Q1RK1 w kq - hmvc 0; fmvn 9;
+rn1qkb1r/pb3ppp/1p3n2/3p4/3pP3/P1N2N2/1PQ2PPP/R1B1KB1R w KQkq - hmvc 0; fmvn 9;
+1n1qkb1r/rp3ppp/p1p1pn2/2PpN2b/3PP3/1QN5/PP3PPP/R1B1KB1R w KQk - hmvc 0; fmvn 9;
+r1bq1rk1/ppp2pbp/2np2p1/4p2n/3P4/4PN1P/PPP1BPPB/RN1Q1RK1 w - e6 hmvc 0; fmvn 9;
+rn1q1rk1/ppp1ppbp/6p1/3n4/3P4/2P2b1P/PP2BPP1/RNBQ1RK1 w - - hmvc 0; fmvn 9;
+r1bq1rk1/ppp1ppbp/5np1/3Pp3/2P1P3/2N4P/PP3PP1/R1BQKB1R w KQ - hmvc 2; fmvn 9;
+r1bq1rk1/pp3pbp/n2ppnp1/2pP4/2P1P3/2NB1N1P/PP3PP1/R1BQK2R w KQ - hmvc 2; fmvn 9;
+r1bqnrk1/pp1nbppp/3p4/2pPp3/2P1P3/2N3P1/PP2NPBP/R1BQK2R w KQ - hmvc 5; fmvn 9;
+r1b1qrk1/ppp2pbp/n2p1np1/4p3/2PP4/2N2NPP/PP2PPB1/R1BQ1RK1 w - e6 hmvc 0; fmvn 9;
+rnb1k1nr/1pqpbp1p/p3p1p1/8/4P1Q1/1NNB4/PPP2PPP/R1B1K2R w KQkq - hmvc 0; fmvn 9;
+rnbqk3/pp2bpp1/3ppn2/7r/3NP3/2N1B3/PPP2P1P/R2QKB1R w KQq - hmvc 0; fmvn 9;
+rn1q1rk1/p2pbppp/bp3n2/2pp4/2P1P3/1QN2NP1/PP3P1P/R1B1KB1R w KQ - hmvc 0; fmvn 9;
+rnq1kb1r/pp2pp1p/2p1bnp1/8/2pPPN2/2N2P2/PP4PP/R1BQKB1R w KQkq - hmvc 0; fmvn 9;
+r1bq1rk1/pppnppbp/1n4p1/1B6/3PP3/2N1B3/PP3PPP/R2QK1NR w KQ - hmvc 5; fmvn 9;
+rnbqkb1r/5ppp/p2p1n2/2pP4/Pp2P3/5NP1/1P3P1P/RNBQKB1R w KQkq - hmvc 0; fmvn 9;
+rn1qkb1r/ppn1pppp/2p1b3/4N3/2PP2P1/8/PP2BP1P/RNBQK2R w KQkq - hmvc 1; fmvn 9;
+1rbqkb1r/p2n1ppp/2n1p3/1pppP3/3P1P2/2PB1N2/PP4PP/R1BQK1NR w KQk b6 hmvc 0; fmvn 9;
+r1bq1rk1/pp1p1ppp/4pn2/4n3/1bPN4/2N3P1/PP2PPBP/R1BQ1RK1 w - - hmvc 7; fmvn 9;
+r1b1kb1r/3pnppp/pqn1p3/1p6/4P3/2NB1N2/PPP2PPP/R1BQ1RK1 w kq - hmvc 6; fmvn 9;
+rnbqk2r/pp2ppb1/2pp1npp/8/3PP2B/2N2P2/PPPQ2PP/R3KBNR w KQkq - hmvc 1; fmvn 9;
+rn1qk2r/pp1bbppp/5n2/1B1p4/3p4/5N2/PPPNQPPP/R1B2RK1 w kq - hmvc 2; fmvn 9;
+rnbqk2r/p1p2pp1/1p2p1n1/3pP2p/3P2QP/P1P5/2P2PP1/R1B1KBNR w KQkq h6 hmvc 0; fmvn 9;
+r2qkb1r/pp2pppp/2p2n2/3n1b2/3P4/5N2/PPP1BPPP/RNBQ1RK1 w kq - hmvc 6; fmvn 9;
+r2qkb1r/pp2pppp/2p2n2/3n4/3P2b1/5N2/PPP1BPPP/RNBQ1RK1 w kq - hmvc 6; fmvn 9;
+rn1qkb1r/4pp1p/p1p2n2/1pPp1p2/3P4/2N1PN2/PP3PPP/R1BQK2R w KQkq - hmvc 0; fmvn 9;
+rn1qk2r/ppp1ppbp/1n2b1p1/8/3P4/2N2N2/PPQ1PPPP/R1B1KB1R w KQkq - hmvc 3; fmvn 9;
+r2qkb1r/1p1bnppp/p3p3/2p5/4PB2/2N2N2/PPP2PPP/R2QK2R w KQkq - hmvc 2; fmvn 9;
+r1bqkb1r/3p1ppp/p1p1p3/3nP3/8/2N5/PPP1BPPP/R1BQK2R w KQkq - hmvc 1; fmvn 9;
+r1b1kb1r/1p2pppp/p1np4/q5B1/3NP1n1/2N4P/PPP2PP1/R2QKB1R w KQkq - hmvc 1; fmvn 9;
+r1bqkb1r/1p3ppp/p1np1n2/4p3/3NPP2/2N1BQ2/PPP3PP/R3KB1R w KQkq - hmvc 0; fmvn 9;
+rnbq1rk1/pp2b1pp/3p1n2/2pP1p2/2P1p3/2N3PN/PP2PPBP/R1BQ1RK1 w - c6 hmvc 0; fmvn 9;
+rnbq1rk1/1p3pbp/p2ppnp1/2pP4/P1P1P3/2N2N1P/1P3PP1/R1BQKB1R w KQ - hmvc 0; fmvn 9;
+rnbq1rk1/pp2ppbp/2p3p1/5n2/3PNB2/2P2N1P/PP3PP1/R2QKB1R w KQ - hmvc 1; fmvn 9;
+r2qkb1r/pp1nn1pp/2p1p3/3ppb2/3P4/1N3N2/PPP1BPPP/R1BQ1RK1 w kq - hmvc 0; fmvn 9;
+r1bq1rk1/ppp1bppp/2n1pn2/2Pp4/Q2P4/P1N1PN2/1P3PPP/R1B1KB1R w KQ - hmvc 1; fmvn 9;
+r1bq1rk1/1p1nppbp/p1p2np1/3p4/2PP1B2/2N1PN1P/PP2BPP1/R2QK2R w KQ - hmvc 2; fmvn 9;
+rnbq1rk1/ppb2ppp/3p1n2/2pP2B1/8/2N1PN2/PP3PPP/R2QKB1R w KQ - hmvc 1; fmvn 9;
+r1bq1rk1/pp3pbp/n2ppnp1/2pP2B1/2P1P3/2N5/PP1QBPPP/R3K1NR w KQ - hmvc 0; fmvn 9;
+r1bqk1nr/1p1p1ppp/p1n1pb2/8/4P3/1N1B2Q1/PPP2PPP/RNB1K2R w KQkq - hmvc 8; fmvn 9;
+r2qk2r/pbpnnpbp/1p1pp1p1/8/3PP3/2PB1N2/PP1N1PPP/R1BQR1K1 w kq - hmvc 4; fmvn 9;
+rn1qkb1r/1p3p1p/p2p1np1/2pP4/4P1b1/2N2N2/PP2QPPP/R1B1KB1R w KQkq - hmvc 2; fmvn 9;
+r2qkb1r/pbp1nppp/1p1pp3/8/2PPP3/2NQ4/PP2NPPP/R1B2RK1 w kq - hmvc 0; fmvn 9;
+rn1qkb1r/1p3ppp/2bp1n2/p3p3/4P3/1NN1BP2/PPP3PP/R2QKB1R w KQkq a6 hmvc 0; fmvn 9;
+r1b1k2r/1p1p1ppp/p1n1pn2/q7/1bPNP3/2N2Q2/PP1B1PPP/R3KB1R w KQkq - hmvc 7; fmvn 9;
+rnb1kb1r/p3pppp/3n4/qppP4/P1p2B2/2N5/1P2NPPP/R2QKB1R w KQkq - hmvc 2; fmvn 9;
+r2qk2r/pb1pppbp/1pn2np1/8/2PNP3/2N1BP2/PP4PP/R2QKB1R w KQkq - hmvc 2; fmvn 9;
+rnbq1rk1/2p2pbp/pp1ppnp1/8/P2PP3/2N2N2/1PP1BPPP/R1BQR1K1 w - - hmvc 0; fmvn 9;
+rnbqrbk1/pp1p1ppp/5n2/2pP2B1/8/2N1PN2/PP3PPP/R2QKB1R w KQ - hmvc 1; fmvn 9;
+rn1q1rk1/pp1nppbp/3p2p1/2p5/2PPP1b1/2N1BN2/PP2BPPP/2RQK2R w K c6 hmvc 0; fmvn 9;
+r1bqk1nr/2pp1pbp/p1n3p1/8/R2pP3/1B3N2/1PP2PPP/1NBQK2R w Kkq - hmvc 1; fmvn 9;
+r1bqkb1r/5ppp/p1pppn2/6B1/4PP2/2N5/PPP3PP/R2QKB1R w KQkq - hmvc 0; fmvn 9;
+1rbq1rk1/pp2ppbp/n2p1np1/2pP4/4PP2/2NB1N2/PPP3PP/R1BQ1RK1 w - - hmvc 1; fmvn 9;
+r1bqk2r/pp2ppbp/3p2pn/8/2BpP3/5Q2/PPPPNPPP/R1B1K2R w KQkq - hmvc 0; fmvn 9;
+rnbq1rk1/pp2ppbp/1n4p1/2p5/3PP3/6P1/PP2NPBP/RNBQ1RK1 w - c6 hmvc 0; fmvn 9;
+r1b1k1nr/2p1qppp/p1p5/2bpp3/8/1P2PN2/PB1P1PPP/RN1QK2R w KQkq - hmvc 0; fmvn 9;
+r2qkb1r/ppp2ppp/2n5/3p4/3P2b1/2PB1N2/P1P2PPP/R1BQK2R w KQkq - hmvc 1; fmvn 9;
+r1bqk2r/1ppn1ppp/3ppn2/6B1/p1PP4/P3PN2/1P3PPP/R2QKB1R w KQkq - hmvc 1; fmvn 9;
+rn1qk2r/p2nbppp/bp2p3/2ppP3/3P4/2PB4/PP1NNPPP/R1BQ1RK1 w kq - hmvc 2; fmvn 9;
+r1b1kbnr/pp1nq3/2pp1pp1/4p2p/2PPP2B/2N2N2/PP2BPPP/R2QK2R w KQkq h6 hmvc 0; fmvn 9;
+rnbqk2r/p3ppbp/3p1np1/2pP4/2P1P3/R1N5/1PQ2PPP/2B1KBNR w Kkq - hmvc 2; fmvn 9;
+rnbqk2r/pp2p1bp/2pp1np1/5P2/3P4/2N3P1/PPP2PB1/R1BQK1NR w KQkq - hmvc 3; fmvn 9;
+r1bqkb1r/pp3ppp/1nn1p3/3pP3/3P4/3B4/PP1NNPPP/R1BQK2R w KQkq - hmvc 1; fmvn 9;
+r3kb1r/pp1n1ppp/2p1pn2/q7/2PP2b1/2N2N2/PP2BPPP/R1BQ1RK1 w kq - hmvc 2; fmvn 9;
+r2qkb1r/pp1b1pp1/n1p1pn1p/3p4/3P1B2/P1NBPP2/1PP1N1PP/R2QK2R w KQkq - hmvc 0; fmvn 9;
+r1bq1rk1/pp2ppbp/2n3pn/3pP3/3P4/2N2N1P/PP3PP1/R1BQKB1R w KQ - hmvc 3; fmvn 9;
+rn1qk2r/ppp1npbp/3p2p1/3P4/8/2N2PP1/PP3P1P/R1BQKB1R w KQkq - hmvc 1; fmvn 9;
+rnbqr1k1/pp1p1pp1/3b1n1p/2pP4/7B/2N2N2/PP2PPPP/R2QKB1R w KQ - hmvc 4; fmvn 9;
+r1b1k1nr/ppq3pp/2n1p3/2ppPp2/3P4/P1P3Q1/2P2PPP/R1B1KBNR w KQkq - hmvc 2; fmvn 9;
+r1bqk1nr/1ppp2bp/2n3p1/5p2/1PP1p3/2N3P1/3PPPBP/1RBQK1NR w Kkq - hmvc 0; fmvn 9;
+r1bqk2r/1p1nppb1/p2p1npp/2pP4/P1B1P3/2N2N2/1PP2PPP/R1BQK2R w KQkq - hmvc 0; fmvn 9;
+rnbq1rk1/ppp3b1/3ppnpp/5p2/2PP4/1P3NP1/PB2PPBP/RN1Q1RK1 w - - hmvc 0; fmvn 9;
+r1bq1rk1/ppn1ppbp/3p1np1/2pP4/4PP2/2NB1N2/PPP3PP/R1BQ1RK1 w - - hmvc 1; fmvn 9;
+r1bqk2r/ppp2ppp/2nn4/1Bb5/3p4/2P2N2/PP3PPP/RNBQ1RK1 w kq - hmvc 0; fmvn 9;

--- a/tests/data/test.epd
+++ b/tests/data/test.epd
@@ -1,3 +1,3 @@
-5k2/3r1p2/1p3pp1/p2n3p/P6P/1PPR1PP1/3KN3/6b1 w - - 0 34
-5k2/5p2/4B2p/r5pn/4P3/5PPP/2NR2K1/8 b - - 0 59
-8/p3kp1p/1p4p1/2r2b2/2BR3P/1P3P2/P4PK1/8 b - - 0 28
+5k2/3r1p2/1p3pp1/p2n3p/P6P/1PPR1PP1/3KN3/6b1 w - - hmvc 0; fmvn 34;
+5k2/5p2/4B2p/r5pn/4P3/5PPP/2NR2K1/8 b - - hmvc 0; fmvn 59;
+8/p3kp1p/1p4p1/2r2b2/2BR3P/1P3P2/P4PK1/8 b - - hmvc 0; fmvn 28;


### PR DESCRIPTION
The current implementation of epd parsing treats all lines inside the epd file as fens and passes it directly to the engine. this is incorrect as the epd notation is not 100% the same as fen notation. for more information, see here: https://www.chessprogramming.org/Extended_Position_Description
cutechess also treats fens and epds differently, see here: https://github.com/cutechess/cutechess/blob/1071d84cf272bd7deca0964336bf02e367e2b22b/projects/lib/src/epdrecord.cpp#L22

fixes issue https://github.com/Disservin/fast-chess/issues/248