### PR TITLE
fix matchcount issue

### DIFF
--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -34,7 +34,8 @@ class BaseTournament {
     [[nodiscard]] stats_map getResults() noexcept { return result_.getResults(); }
     void setResults(const stats_map &results) noexcept { 
        result_.setResults(results); 
-       match_count_ = result_.getResults().wins + result_.getResults().losses + result_.getResults().draws;
+       const auto &stats = result_.getResults();
+       match_count_ = stats.wins + stats.losses + stats.draws;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -44,7 +44,7 @@ class BaseTournament {
 
    protected:
     /// @brief number of games played
-    std::atomic<uint64_t> match_count_ = 0;
+    std::atomic<uint64_t> match_count_;
 
     /// @brief creates the matches
     virtual void create() = 0;

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -34,8 +34,23 @@ class BaseTournament {
     [[nodiscard]] stats_map getResults() noexcept { return result_.getResults(); }
     void setResults(const stats_map &results) noexcept { 
        result_.setResults(results); 
-       const auto &stats = result_.getResults();
-       match_count_ = stats.wins + stats.losses + stats.draws;
+       uint64_t total_wins = 0;
+       uint64_t total_losses = 0;
+       uint64_t total_draws = 0;
+   
+       // Iterate over the outer map
+       for (const auto &pair1 : result_.getResults()) {
+           const auto &inner_map = pair1.second;
+           // Iterate over the inner map
+           for (const auto &pair2 : inner_map) {
+               const Stats &stats = pair2.second;
+               total_wins += stats.wins;
+               total_losses += stats.losses;
+               total_draws += stats.draws;
+           }
+       }
+
+       match_count_ = total_wins + total_losses + total_draws;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -35,7 +35,22 @@ class BaseTournament {
     void setResults(const stats_map &results) noexcept { 
        result_.setResults(results);
 
-       match_count_ = result_.wins + result_.losses + result_.draws;
+       uint64_t total_wins = 0;
+       uint64_t total_losses = 0;
+       uint64_t total_draws = 0;
+       
+       // Iterate over the outer map
+       for (const auto &pair1 : result_.getResults()) {
+           const auto &inner_map = pair1.second;
+           // Iterate over the inner map
+           for (const auto &pair2 : inner_map) {
+               const Stats &stats = pair2.second;
+               total_wins += stats.wins;
+               total_losses += stats.losses;
+               total_draws += stats.draws;
+           }
+       }
+       match_count_ = total_wins + total_losses + total_draws;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -32,13 +32,19 @@ class BaseTournament {
     virtual void stop();
 
     [[nodiscard]] stats_map getResults() noexcept { return result_.getResults(); }
-    void setResults(const stats_map &results) noexcept { result_.setResults(results); }
+    void setResults(const stats_map &results) noexcept { 
+       result_.setResults(results); 
+       match_count_ = result_.getResults().wins + result_.getResults().losses + result_.getResults().draws;
+    }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {
         tournament_options_ = tournament_config;
     }
 
    protected:
+    /// @brief number of games played
+    std::atomic<uint64_t> match_count_ = 0;
+
     /// @brief creates the matches
     virtual void create() = 0;
 

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -33,24 +33,9 @@ class BaseTournament {
 
     [[nodiscard]] stats_map getResults() noexcept { return result_.getResults(); }
     void setResults(const stats_map &results) noexcept { 
-       result_.setResults(results); 
-       uint64_t total_wins = 0;
-       uint64_t total_losses = 0;
-       uint64_t total_draws = 0;
-   
-       // Iterate over the outer map
-       for (const auto &pair1 : result_.getResults()) {
-           const auto &inner_map = pair1.second;
-           // Iterate over the inner map
-           for (const auto &pair2 : inner_map) {
-               const Stats &stats = pair2.second;
-               total_wins += stats.wins;
-               total_losses += stats.losses;
-               total_draws += stats.draws;
-           }
-       }
+       result_.setResults(results);
 
-       match_count_ = total_wins + total_losses + total_draws;
+       match_count_ = result_.wins + result_.losses + result_.draws;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {

--- a/src/matchmaking/tournament/roundrobin/roundrobin.hpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.hpp
@@ -39,8 +39,6 @@ class RoundRobin : public BaseTournament {
 
     SPRT sprt_ = SPRT();
 
-    /// @brief number of games played
-    std::atomic<uint64_t> match_count_ = 0;
     /// @brief number of games to be played
     std::atomic<uint64_t> total_ = 0;
 };


### PR DESCRIPTION
This only fixes the termination criterion of the tournament so that fixed tests dont run longer than it should. the number of rounds and games displayed are still not fixed :(

partly solves https://github.com/Disservin/fast-chess/issues/244 