### PR TITLE
Fix matchcount resetting after saving and loading test

### DIFF
--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -34,7 +34,8 @@ class BaseTournament {
     [[nodiscard]] stats_map getResults() noexcept { return result_.getResults(); }
     void setResults(const stats_map &results) noexcept { 
        result_.setResults(results); 
-       match_count_ = result_.getResults().wins + result_.getResults().losses + result_.getResults().draws;
+       const auto &stats = result_.getResults();
+       match_count_ = stats.wins + stats.losses + stats.draws;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -51,6 +51,7 @@ class BaseTournament {
            }
        }
        match_count_ = total_wins + total_losses + total_draws;
+       initial_id_  = match_count_;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {
@@ -60,6 +61,7 @@ class BaseTournament {
    protected:
     /// @brief number of games played
     std::atomic<uint64_t> match_count_;
+    std::atomic<uint64_t> initial_id_;
 
     /// @brief creates the matches
     virtual void create() = 0;

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -61,7 +61,7 @@ class BaseTournament {
    protected:
     /// @brief number of games played
     std::atomic<uint64_t> match_count_;
-    std::atomic<uint64_t> initial_id_;
+    uint64_t initial_id_;
 
     /// @brief creates the matches
     virtual void create() = 0;

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -44,7 +44,7 @@ class BaseTournament {
 
    protected:
     /// @brief number of games played
-    std::atomic<uint64_t> match_count_ = 0;
+    std::atomic<uint64_t> match_count_;
 
     /// @brief creates the matches
     virtual void create() = 0;

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -34,8 +34,23 @@ class BaseTournament {
     [[nodiscard]] stats_map getResults() noexcept { return result_.getResults(); }
     void setResults(const stats_map &results) noexcept { 
        result_.setResults(results); 
-       const auto &stats = result_.getResults();
-       match_count_ = stats.wins + stats.losses + stats.draws;
+       uint64_t total_wins = 0;
+       uint64_t total_losses = 0;
+       uint64_t total_draws = 0;
+   
+       // Iterate over the outer map
+       for (const auto &pair1 : result_.getResults()) {
+           const auto &inner_map = pair1.second;
+           // Iterate over the inner map
+           for (const auto &pair2 : inner_map) {
+               const Stats &stats = pair2.second;
+               total_wins += stats.wins;
+               total_losses += stats.losses;
+               total_draws += stats.draws;
+           }
+       }
+
+       match_count_ = total_wins + total_losses + total_draws;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -35,7 +35,22 @@ class BaseTournament {
     void setResults(const stats_map &results) noexcept { 
        result_.setResults(results);
 
-       match_count_ = result_.wins + result_.losses + result_.draws;
+       uint64_t total_wins = 0;
+       uint64_t total_losses = 0;
+       uint64_t total_draws = 0;
+       
+       // Iterate over the outer map
+       for (const auto &pair1 : result_.getResults()) {
+           const auto &inner_map = pair1.second;
+           // Iterate over the inner map
+           for (const auto &pair2 : inner_map) {
+               const Stats &stats = pair2.second;
+               total_wins += stats.wins;
+               total_losses += stats.losses;
+               total_draws += stats.draws;
+           }
+       }
+       match_count_ = total_wins + total_losses + total_draws;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -32,13 +32,19 @@ class BaseTournament {
     virtual void stop();
 
     [[nodiscard]] stats_map getResults() noexcept { return result_.getResults(); }
-    void setResults(const stats_map &results) noexcept { result_.setResults(results); }
+    void setResults(const stats_map &results) noexcept { 
+       result_.setResults(results); 
+       match_count_ = result_.getResults().wins + result_.getResults().losses + result_.getResults().draws;
+    }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {
         tournament_options_ = tournament_config;
     }
 
    protected:
+    /// @brief number of games played
+    std::atomic<uint64_t> match_count_ = 0;
+
     /// @brief creates the matches
     virtual void create() = 0;
 

--- a/src/matchmaking/tournament/base/tournament.hpp
+++ b/src/matchmaking/tournament/base/tournament.hpp
@@ -33,24 +33,9 @@ class BaseTournament {
 
     [[nodiscard]] stats_map getResults() noexcept { return result_.getResults(); }
     void setResults(const stats_map &results) noexcept { 
-       result_.setResults(results); 
-       uint64_t total_wins = 0;
-       uint64_t total_losses = 0;
-       uint64_t total_draws = 0;
-   
-       // Iterate over the outer map
-       for (const auto &pair1 : result_.getResults()) {
-           const auto &inner_map = pair1.second;
-           // Iterate over the inner map
-           for (const auto &pair2 : inner_map) {
-               const Stats &stats = pair2.second;
-               total_wins += stats.wins;
-               total_losses += stats.losses;
-               total_draws += stats.draws;
-           }
-       }
+       result_.setResults(results);
 
-       match_count_ = total_wins + total_losses + total_draws;
+       match_count_ = result_.wins + result_.losses + result_.draws;
     }
 
     void setGameConfig(const options::Tournament &tournament_config) noexcept {

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -32,6 +32,7 @@ void RoundRobin::create() {
              tournament_options_.rounds * tournament_options_.games;
 
     const auto create_match = [this](std::size_t i, std::size_t j, std::size_t round_id) {
+        round_id += initial_id_ / tournament_options_.games;
         constexpr auto normalize_stm_configs = [](const pair_config& configs,
                                                   const chess::Color stm) {
             // swap players if the opening is for black, to ensure that

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -32,7 +32,6 @@ void RoundRobin::create() {
              tournament_options_.rounds * tournament_options_.games;
 
     const auto create_match = [this](std::size_t i, std::size_t j, std::size_t round_id) {
-        round_id += initial_id_ / tournament_options_.games;
         constexpr auto normalize_stm_configs = [](const pair_config& configs,
                                                   const chess::Color stm) {
             // swap players if the opening is for black, to ensure that
@@ -108,7 +107,7 @@ void RoundRobin::create() {
 
     for (std::size_t i = 0; i < engine_configs_.size(); i++) {
         for (std::size_t j = i + 1; j < engine_configs_.size(); j++) {
-            for (int k = 0; k < tournament_options_.rounds; k++) {
+            for (int k = initial_id_ / tournament_options_.games; k < tournament_options_.rounds; k++) {
                 create_match(i, j, k);
             }
         }

--- a/src/matchmaking/tournament/roundrobin/roundrobin.hpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.hpp
@@ -39,8 +39,6 @@ class RoundRobin : public BaseTournament {
 
     SPRT sprt_ = SPRT();
 
-    /// @brief number of games played
-    std::atomic<uint64_t> match_count_ = 0;
     /// @brief number of games to be played
     std::atomic<uint64_t> total_ = 0;
 };


### PR DESCRIPTION
fixes issue https://github.com/Disservin/fast-chess/issues/244
fixed output:
```
C:\Users\Gahtan Syarif Nahdi\Downloads\fast-chess-matchcount5\fast-chess-matchcount5>fast-chess.exe -openings file=openingss.epd format=epd order=sequential -engine cmd=Stockfish-dev-20240413-c55ae376.exe name=Engine1 -engine cmd=Stockfish-dev-20240413-c55ae376.exe name=Engine2 -each tc=10+0.1 -rounds 4 -concurrency 4 -resign movecount=1 score=600 -pgnout file=fastchess.pgn\
Starting tournament...
Started game 1 of 8 (Engine1 vs Engine2)
Started game 4 of 8 (Engine2 vs Engine1)
Started game 3 of 8 (Engine1 vs Engine2)
Started game 2 of 8 (Engine2 vs Engine1)
Finished game 4 (Engine2 vs Engine1): 1-0 {Engine1 loses by adjudication}
Started game 5 of 8 (Engine1 vs Engine2)
Finished game 1 (Engine1 vs Engine2): 1-0 {Engine1 wins by adjudication}
Started game 6 of 8 (Engine2 vs Engine1)
Finished game 2 (Engine2 vs Engine1): 1/2-1/2 {Draw by 3-fold repetition}
--------------------------------------------------
Results of Engine1 vs Engine2:
Elo: 190.85 +/- 0.00, nElo: inf +/- nan
LOS: 100.00 %, DrawRatio: 0.00 %, PairsRatio: inf
Games: 2, Wins: 1, Losses: 0, Draws: 1, Points: 1.5 (75.00 %)
Ptnml(0-2): [0, 0, 0, 1, 0]
--------------------------------------------------
Started game 7 of 8 (Engine1 vs Engine2)
Finished game 3 (Engine1 vs Engine2): 1/2-1/2 {Draw by 3-fold repetition}
--------------------------------------------------
Results of Engine1 vs Engine2:
Elo: -0.00 +/- 296.58, nElo: 0.00 +/- 340.48
LOS: 50.00 %, DrawRatio: 0.00 %, PairsRatio: 1.00
Games: 4, Wins: 1, Losses: 1, Draws: 2, Points: 2.0 (50.00 %)
Ptnml(0-2): [0, 1, 0, 1, 0]
--------------------------------------------------
Started game 8 of 8 (Engine2 vs Engine1)
Finished tournament.
Saved results.

C:\Users\Gahtan Syarif Nahdi\Downloads\fast-chess-matchcount5\fast-chess-matchcount5>fast-chess.exe -config file=config.json
Loading config file:  config.json
Starting tournament...
Started game 5 of 8 (Engine1 vs Engine2)
Started game 7 of 8 (Engine1 vs Engine2)
Started game 6 of 8 (Engine2 vs Engine1)
Started game 8 of 8 (Engine2 vs Engine1)
Finished game 7 (Engine1 vs Engine2): 1/2-1/2 {Draw by 3-fold repetition}
Finished game 8 (Engine2 vs Engine1): 1/2-1/2 {Draw by 3-fold repetition}
--------------------------------------------------
Results of Engine1 vs Engine2:
Elo: -0.00 +/- 173.65, nElo: -0.00 +/- 278.00
LOS: 50.00 %, DrawRatio: 33.33 %, PairsRatio: 1.00
Games: 6, Wins: 1, Losses: 1, Draws: 4, Points: 3.0 (50.00 %)
Ptnml(0-2): [0, 1, 1, 1, 0]
--------------------------------------------------
Finished game 5 (Engine1 vs Engine2): 1-0 {Engine2 loses by adjudication}
Finished game 6 (Engine2 vs Engine1): 1/2-1/2 {Draw by 3-fold repetition}
--------------------------------------------------
Results of Engine1 vs Engine2:
Elo: 43.66 +/- 153.04, nElo: 74.07 +/- 240.76
LOS: 72.68 %, DrawRatio: 25.00 %, PairsRatio: 2.00
Games: 8, Wins: 2, Losses: 1, Draws: 5, Points: 4.5 (56.25 %)
Ptnml(0-2): [0, 1, 1, 2, 0]
--------------------------------------------------
Finished tournament.
Saved results.
```
