### PR TITLE
fix: huge memory consumption with large number of rounds

### DIFF
--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -31,7 +31,8 @@ void RoundRobin::create() {
     total_ = (engine_configs_.size() * (engine_configs_.size() - 1) / 2) *
              tournament_options_.rounds * tournament_options_.games;
 
-    const auto create_match = [this](std::size_t i, std::size_t j, std::size_t round_id, int g) {
+    const auto create_match = [this](std::size_t i, std::size_t j, std::size_t round_id, int g,
+                                     Opening opening) {
         constexpr auto normalize_stm_configs = [](const pair_config& configs,
                                                   const chess::Color stm) {
             // swap players if the opening is for black, to ensure that
@@ -53,12 +54,10 @@ void RoundRobin::create() {
             return stats;
         };
 
-        // both players get the same opening
-        const auto opening = book_.fetch();
-        const auto stm     = opening.stm;
-        const auto first   = engine_configs_[i];
-        const auto second  = engine_configs_[j];
-        auto configs       = std::pair{engine_configs_[i], engine_configs_[j]};
+        const auto stm    = opening.stm;
+        const auto first  = engine_configs_[i];
+        const auto second = engine_configs_[j];
+        auto configs      = std::pair{engine_configs_[i], engine_configs_[j]};
 
         assert(g < 2);
         if (g == 1) {
@@ -112,8 +111,11 @@ void RoundRobin::create() {
         for (std::size_t j = i + 1; j < engine_configs_.size(); j++) {
             auto offset = initial_matchcount_ / tournament_options_.games;
             for (int k = offset; k < tournament_options_.rounds; k++) {
+                // both players get the same opening
+                const auto opening = book_.fetch();
+
                 for (int g = 0; g < tournament_options_.games; g++) {
-                    pool_.enqueue(create_match, i, j, k, g);
+                    pool_.enqueue(create_match, i, j, k, g, opening);
                 }
             }
         }

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -31,7 +31,7 @@ void RoundRobin::create() {
     total_ = (engine_configs_.size() * (engine_configs_.size() - 1) / 2) *
              tournament_options_.rounds * tournament_options_.games;
 
-    const auto create_match = [this](std::size_t i, std::size_t j, std::size_t round_id) {
+    const auto create_match = [this](std::size_t i, std::size_t j, std::size_t round_id, int g) {
         constexpr auto normalize_stm_configs = [](const pair_config& configs,
                                                   const chess::Color stm) {
             // swap players if the opening is for black, to ensure that
@@ -60,59 +60,61 @@ void RoundRobin::create() {
         const auto second  = engine_configs_[j];
         auto configs       = std::pair{engine_configs_[i], engine_configs_[j]};
 
-        for (int g = 0; g < tournament_options_.games; g++) {
-            const std::size_t game_id = round_id * tournament_options_.games + (g + 1);
-
-            // callback functions, do not capture by reference
-            const auto start = [this, configs, game_id, stm, normalize_stm_configs]() {
-                output_->startGame(normalize_stm_configs(configs, stm), game_id, total_);
-            };
-
-            // callback functions, do not capture by reference
-            const auto finish = [this, configs, first, second, game_id, round_id, stm,
-                                 normalize_stm_configs,
-                                 normalize_stats](const Stats& stats, const std::string& reason) {
-                const auto normalized_configs = normalize_stm_configs(configs, stm);
-                const auto normalized_stats   = normalize_stats(stats, stm);
-
-                output_->endGame(normalized_configs, normalized_stats, reason, game_id);
-
-                bool report = true;
-
-                if (tournament_options_.report_penta) {
-                    report = result_.updatePairStats(configs, first.name, stats, round_id);
-                } else {
-                    result_.updateStats(configs, stats);
-                }
-
-                // game_id starts 1 and round_id starts 0
-                auto interval_index = tournament_options_.report_penta ? round_id + 1 : game_id;
-
-                // Only print the interval if the pair is complete or we are not tracking
-                // penta stats.
-                if (report && interval_index % tournament_options_.ratinginterval == 0) {
-                    const auto updated_stats = result_.getStats(first.name, second.name);
-
-                    output_->printInterval(sprt_, updated_stats, first.name, second.name);
-                }
-
-                updateSprtStatus({first, second});
-
-                match_count_++;
-            };
-
-            pool_.enqueue(&RoundRobin::playGame, this, configs, start, finish, opening, round_id);
-
-            // swap players
+        assert(g < 2);
+        if (g == 1) {
             std::swap(configs.first, configs.second);
         }
+
+        const std::size_t game_id = round_id * tournament_options_.games + (g + 1);
+
+        // callback functions, do not capture by reference
+        const auto start = [this, configs, game_id, stm, normalize_stm_configs]() {
+            output_->startGame(normalize_stm_configs(configs, stm), game_id, total_);
+        };
+
+        // callback functions, do not capture by reference
+        const auto finish = [this, configs, first, second, game_id, round_id, stm,
+                             normalize_stm_configs,
+                             normalize_stats](const Stats& stats, const std::string& reason) {
+            const auto normalized_configs = normalize_stm_configs(configs, stm);
+            const auto normalized_stats   = normalize_stats(stats, stm);
+
+            output_->endGame(normalized_configs, normalized_stats, reason, game_id);
+
+            bool report = true;
+
+            if (tournament_options_.report_penta) {
+                report = result_.updatePairStats(configs, first.name, stats, round_id);
+            } else {
+                result_.updateStats(configs, stats);
+            }
+
+            // game_id starts 1 and round_id starts 0
+            auto interval_index = tournament_options_.report_penta ? round_id + 1 : game_id;
+
+            // Only print the interval if the pair is complete or we are not tracking
+            // penta stats.
+            if (report && interval_index % tournament_options_.ratinginterval == 0) {
+                const auto updated_stats = result_.getStats(first.name, second.name);
+
+                output_->printInterval(sprt_, updated_stats, first.name, second.name);
+            }
+
+            updateSprtStatus({first, second});
+
+            match_count_++;
+        };
+
+        playGame(configs, start, finish, opening, round_id);
     };
 
     for (std::size_t i = 0; i < engine_configs_.size(); i++) {
         for (std::size_t j = i + 1; j < engine_configs_.size(); j++) {
-            for (int k = initial_matchcount_ / tournament_options_.games;
-                 k < tournament_options_.rounds; k++) {
-                create_match(i, j, k);
+            auto offset = initial_matchcount_ / tournament_options_.games;
+            for (int k = offset; k < tournament_options_.rounds; k++) {
+                for (int g = 0; g < tournament_options_.games; g++) {
+                    pool_.enqueue(create_match, i, j, k, g);
+                }
             }
         }
     }


### PR DESCRIPTION
Actually I think the fix is rather easy, we can just enqueue the create_match function with the round parameters.

before: 
```
➜  fast-chess git:(master) ./fast-chess -openings file=openings.epd format=epd order=random -engine cmd=../Stockfish/src/stockfish name=stockfish -engine cmd=../Stockfish/src/stockfish name=stockfish2 -each tc=1+0.01 -rounds 10240000 -games 2 -concurrency 2 -resign movecount=1 score=600 -pgnout file=fastchess.pgn -srand 4555321
Starting tournament...
Started game 1 of 20480000 (stockfish vs stockfish2)
Started game 2 of 20480000 (stockfish2 vs stockfish)
Finished game 1 (stockfish vs stockfish2): 1-0 {stockfish2 loses by adjudication}
Started game 3 of 20480000 (stockfish vs stockfish2)
Finished game 2 (stockfish2 vs stockfish): 1-0 {stockfish loses by adjudication}
Started game 4 of 20480000 (stockfish2 vs stockfish)
Finished game 4 (stockfish2 vs stockfish): 1-0 {stockfish loses by adjudication}
Started game 5 of 20480000 (stockfish vs stockfish2)
Finished game 3 (stockfish vs stockfish2): 1-0 {stockfish2 loses by adjudication}
Started game 6 of 20480000 (stockfish2 vs stockfish)
Finished game 5 (stockfish vs stockfish2): 1-0 {stockfish2 loses by adjudication}
Started game 7 of 20480000 (stockfish vs stockfish2)
Finished game 6 (stockfish2 vs stockfish): 1-0 {stockfish2 wins by adjudication}
Started game 8 of 20480000 (stockfish2 vs stockfish)
[1]    65292 killed     ./fast-chess -openings file=openings.epd format=epd order=random -engine
```

htop output grew to 15G / 15G and 4G of swap.

After:
```
➜  fast-chess git:(197-huge-memory-consumption-with-large-number-of-rounds) ./fast-chess -openings file=openings.epd format=epd order=random -engine cmd=../Stockfish/src/stockfish name=stockfish -engine cmd=../Stockfish/src/stockfish name=stockfish2 -each tc=1+0.01 -rounds 10240000 -games 2 -concurrency 2 -resign movecount=1 score=600 -pgnout file=fastchess.pgn -srand 4555321
Starting tournament...
Started game 1 of 20480000 (stockfish vs stockfish2)
Started game 2 of 20480000 (stockfish2 vs stockfish)
Finished game 2 (stockfish2 vs stockfish): 1/2-1/2 {Draw by 3-fold repetition}
Started game 3 of 20480000 (stockfish vs stockfish2)
Finished game 1 (stockfish vs stockfish2): 1-0 {stockfish wins by adjudication}
Started game 4 of 20480000 (stockfish2 vs stockfish)
Finished game 3 (stockfish vs stockfish2): 1-0 {stockfish wins by adjudication}
Started game 5 of 20480000 (stockfish vs stockfish2)
Finished game 4 (stockfish2 vs stockfish): 1/2-1/2 {Draw by insufficient material}
Started game 6 of 20480000 (stockfish2 vs stockfish)
Finished game 5 (stockfish vs stockfish2): 1-0 {stockfish2 loses by adjudication}
Started game 7 of 20480000 (stockfish vs stockfish2)
Finished game 6 (stockfish2 vs stockfish): 1/2-1/2 {Draw by 3-fold repetition}
Started game 8 of 20480000 (stockfish2 vs stockfish)
Finished game 8 (stockfish2 vs stockfish): 1/2-1/2 {Draw by 3-fold repetition}
Started game 9 of 20480000 (stockfish vs stockfish2)
Finished game 7 (stockfish vs stockfish2): 1/2-1/2 {Draw by 50-move rule}
Started game 10 of 20480000 (stockfish2 vs stockfish)
Finished game 9 (stockfish vs stockfish2): 1-0 {stockfish2 loses by adjudication}
Started game 11 of 20480000 (stockfish vs stockfish2)
Finished game 10 (stockfish2 vs stockfish): 1-0 {stockfish2 wins by adjudication}
Started game 12 of 20480000 (stockfish2 vs stockfish)
Finished game 11 (stockfish vs stockfish2): 1-0 {stockfish2 loses by adjudication}
Started game 13 of 20480000 (stockfish vs stockfish2)
Finished game 12 (stockfish2 vs stockfish): 1-0 {stockfish loses by adjudication}
Started game 14 of 20480000 (stockfish2 vs stockfish)
Finished game 13 (stockfish vs stockfish2): 1-0 {stockfish wins by adjudication}
Started game 15 of 20480000 (stockfish vs stockfish2)
Finished game 14 (stockfish2 vs stockfish): 1/2-1/2 {Draw by 3-fold repetition}
Started game 16 of 20480000 (stockfish2 vs stockfish)
...
```

htop shows only about 11G / 15G to be used.

note: this was not the total amount of ram used for fastchess, just the total used in the system.

fixes https://github.com/Disservin/fast-chess/issues/197