### PR TITLE
feat: add -timemargin option

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -404,6 +404,10 @@ void parseRatinginterval(int &i, int argc, char const *argv[], ArgumentData &arg
     parseValue(i, argc, argv, argument_data.tournament_options.ratinginterval);
 }
 
+void parseTimemargin(int &i, int argc, char const *argv[], ArgumentData &argument_data) {
+    parseValue(i, argc, argv, argument_data.tournament_options.timemargin);
+}
+
 void parseSRand(int &i, int argc, char const *argv[], ArgumentData &argument_data) {
     parseValue(i, argc, argv, argument_data.tournament_options.seed);
 }
@@ -518,6 +522,7 @@ OptionsParser::OptionsParser(int argc, char const *argv[]) {
     addOption("games", parseGames);
     addOption("rounds", parseRounds);
     addOption("ratinginterval", parseRatinginterval);
+    addOption("timemargin", parseTimemargin);
     addOption("srand", parseSRand);
     addOption("version", parseVersion);
     addOption("-version", parseVersion);

--- a/src/matchmaking/match/match.cpp
+++ b/src/matchmaking/match/match.cpp
@@ -187,7 +187,7 @@ bool Match::playMove(Player& us, Player& opponent) {
 
     // Time forfeit
     const auto elapsed_millis = chrono::duration_cast<chrono::milliseconds>(t1 - t0).count();
-    if (!us.updateTime(elapsed_millis)) {
+    if (!us.updateTime(elapsed_millis, tournament_options_.timemargin)) {
         setLose(us, opponent);
 
         data_.termination = MatchTermination::TIMEOUT;

--- a/src/matchmaking/player.hpp
+++ b/src/matchmaking/player.hpp
@@ -37,10 +37,14 @@ class Player {
 
         time_control_.time -= elapsed_millis;
 
-        if (time_control_.time < 0) {
+        if (time_control_.time < -timemargin) {
             return false;
         }
 
+        if (time_control_.time < 0) {
+            time_control_.time = 0;
+        }
+       
         time_control_.time += time_control_.increment;
 
         return true;

--- a/src/matchmaking/player.hpp
+++ b/src/matchmaking/player.hpp
@@ -30,7 +30,7 @@ class Player {
     /// @brief remove the elapsed time from the participant's time
     /// @param elapsed_millis
     /// @return `false` when out of time
-    [[nodiscard]] bool updateTime(const int64_t elapsed_millis) {
+    [[nodiscard]] bool updateTime(const int64_t elapsed_millis, const int64_t timemargin) {
         if (engine.getConfig().limit.tc.time == 0) {
             return true;
         }

--- a/src/matchmaking/tournament/tournament_manager.cpp
+++ b/src/matchmaking/tournament/tournament_manager.cpp
@@ -9,7 +9,7 @@ TournamentManager::TournamentManager(const options::Tournament& tournament_confi
     : engine_configs_(engine_configs), tournament_options_(tournament_config) {
     validateEngines();
 
-    if (tournament_options_.randomseed == true && round_id == 0) {
+    if (tournament_options_.randomseed == true && initial_matchcount_ == 0) {
         std::random_device rd;   // Random device to seed the generator
         std::mt19937 gen(rd());  // Mersenne Twister 19937 generator
         std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());

--- a/src/matchmaking/tournament/tournament_manager.cpp
+++ b/src/matchmaking/tournament/tournament_manager.cpp
@@ -43,6 +43,10 @@ options::Tournament TournamentManager::fixConfig(options::Tournament config) {
 
     if (config.report_penta && config.games != 2) config.report_penta = false;
 
+    if (config.timemargin < 0){
+       throw std::runtime_error("Error: timemargin cannot be a negative number");
+    }
+
     if (config.opening.file.empty()) {
         Logger::log<Logger::Level::WARN>(
             "Warning: No opening book specified! Consider using one, otherwise all games will be "

--- a/src/matchmaking/tournament/tournament_manager.cpp
+++ b/src/matchmaking/tournament/tournament_manager.cpp
@@ -10,10 +10,12 @@ TournamentManager::TournamentManager(const options::Tournament& tournament_confi
     validateEngines();
 
     if (tournament_options_.randomseed == true && tournament_options_.seed == 951356066) {
-        std::random_device rd;   // Random device to seed the generator
-        std::mt19937 gen(rd());  // Mersenne Twister 19937 generator
-        std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());
-        tournament_options_.seed = dist(gen);
+       while(tournament_options_.seed == 951356066){
+          std::random_device rd;   // Random device to seed the generator
+          std::mt19937 gen(rd());  // Mersenne Twister 19937 generator
+          std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());
+          tournament_options_.seed = dist(gen);
+       }
     }
 
     // Set the seed for the random number generator

--- a/src/matchmaking/tournament/tournament_manager.cpp
+++ b/src/matchmaking/tournament/tournament_manager.cpp
@@ -9,7 +9,7 @@ TournamentManager::TournamentManager(const options::Tournament& tournament_confi
     : engine_configs_(engine_configs), tournament_options_(tournament_config) {
     validateEngines();
 
-    if (tournament_options_.randomseed == true) {
+    if (tournament_options_.randomseed == true && round_id == 0) {
         std::random_device rd;   // Random device to seed the generator
         std::mt19937 gen(rd());  // Mersenne Twister 19937 generator
         std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());

--- a/src/matchmaking/tournament/tournament_manager.cpp
+++ b/src/matchmaking/tournament/tournament_manager.cpp
@@ -9,7 +9,7 @@ TournamentManager::TournamentManager(const options::Tournament& tournament_confi
     : engine_configs_(engine_configs), tournament_options_(tournament_config) {
     validateEngines();
 
-    if (tournament_options_.randomseed == true && tournament_options_.seed != 951356066) {
+    if (tournament_options_.randomseed == true && tournament_options_.seed == 951356066) {
         std::random_device rd;   // Random device to seed the generator
         std::mt19937 gen(rd());  // Mersenne Twister 19937 generator
         std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());

--- a/src/matchmaking/tournament/tournament_manager.cpp
+++ b/src/matchmaking/tournament/tournament_manager.cpp
@@ -9,7 +9,7 @@ TournamentManager::TournamentManager(const options::Tournament& tournament_confi
     : engine_configs_(engine_configs), tournament_options_(tournament_config) {
     validateEngines();
 
-    if (tournament_options_.randomseed == true && initial_matchcount_ == 0) {
+    if (tournament_options_.randomseed == true && tournament_options_.seed != 951356066) {
         std::random_device rd;   // Random device to seed the generator
         std::mt19937 gen(rd());  // Mersenne Twister 19937 generator
         std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -101,6 +101,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Tournament, resign, draw, openin
                                                 event_name, site, output, seed, variant,
                                                 ratinginterval, games, rounds, concurrency,
                                                 overhead, timemargin, recover, report_penta, 
-                                                affinity)
+                                                affinity, randomseed)
 
 }  // namespace fast_chess::options

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -84,6 +84,8 @@ struct Tournament {
     int concurrency = 1;
     int overhead    = 0;
 
+    int timemargin  = 0;
+
     bool recover      = false;
     bool report_penta = true;
     bool affinity     = true;
@@ -92,7 +94,7 @@ struct Tournament {
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Tournament, resign, draw, opening, pgn, sprt,
                                                 event_name, site, output, seed, variant,
                                                 ratinginterval, games, rounds, concurrency,
-                                                overhead, recover, report_penta, affinity,
-                                                randomseed)
+                                                overhead, timemargin, recover, report_penta, 
+                                                affinity, randomseed)
 
 }  // namespace fast_chess::options

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -97,7 +97,7 @@ struct Tournament {
     bool affinity     = true;
     bool randomseed   = false;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Tournament, resign, draw, opening, pgn, sprt,
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Tournament, resign, draw, opening, pgn, epd, sprt,
                                                 event_name, site, output, seed, variant,
                                                 ratinginterval, games, rounds, concurrency,
                                                 overhead, timemargin, recover, report_penta, 

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -101,6 +101,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Tournament, resign, draw, openin
                                                 event_name, site, output, seed, variant,
                                                 ratinginterval, games, rounds, concurrency,
                                                 overhead, timemargin, recover, report_penta, 
-                                                affinity, randomseed)
+                                                affinity)
 
 }  // namespace fast_chess::options


### PR DESCRIPTION
I set the time control to 0 if its below 0 so it prevents negative time which i feel might lead to weird behavior,
and the way i see it, the timemargin is just an extra time after the actual time control that the engine is alloted, so after the move is made it shouldnt be part of the calculation for the final time after increment is added,
say an engine exceeded the timelimit by 250ms with a 1 second increment, this way the final time after the move should be 1 second instead of 750ms

fix https://github.com/Disservin/fast-chess/issues/285