### PR TITLE
fix: reformat pgn date tag and change pgn tag order to follow standard

### DIFF
--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -35,7 +35,7 @@ PgnBuilder::PgnBuilder(const MatchData &match, const options::Tournament &tourna
                         ? str::to_string(white_player.config.limit.tc)
                         : str::to_string(white_player.config.limit.tc) + "; " +
                               str::to_string(black_player.config.limit.tc);
-    
+
     addHeader("Event", tournament_options.event_name);
     addHeader("Site", game_options_.site);
     addHeader("Date", match_.date);

--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -38,10 +38,10 @@ PgnBuilder::PgnBuilder(const MatchData &match, const options::Tournament &tourna
 
     addHeader("Event", tournament_options.event_name);
     addHeader("Site", game_options_.site);
+    addHeader("Date", match_.date);
     addHeader("Round", std::to_string(round_id));
     addHeader("White", white_player.config.name);
     addHeader("Black", black_player.config.name);
-    addHeader("Date", match_.date);
     addHeader("Result", getResultFromMatch(white_player, black_player));
 
     if (match_.fen != chess::constants::STARTPOS ||

--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -37,9 +37,12 @@ PgnBuilder::PgnBuilder(const MatchData &match, const options::Tournament &tourna
                         : str::to_string(white_player.config.limit.tc) + "; " +
                               str::to_string(black_player.config.limit.tc);
 
+    std::string pgn_date = match_.date;
+    replace(pgn_date.begin(), pgn_date.end(), '-', '.');
+    
     addHeader("Event", tournament_options.event_name);
     addHeader("Site", game_options_.site);
-    addHeader("Date", replace(match_.date.begin(), match_.date.end(), '-', '.'));
+    addHeader("Date", pgn_date);
     addHeader("Round", std::to_string(round_id));
     addHeader("White", white_player.config.name);
     addHeader("Black", black_player.config.name);

--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -36,13 +36,10 @@ PgnBuilder::PgnBuilder(const MatchData &match, const options::Tournament &tourna
                         ? str::to_string(white_player.config.limit.tc)
                         : str::to_string(white_player.config.limit.tc) + "; " +
                               str::to_string(black_player.config.limit.tc);
-
-    std::string pgn_date = match_.date;
-    replace(pgn_date.begin(), pgn_date.end(), '-', '.');
     
     addHeader("Event", tournament_options.event_name);
     addHeader("Site", game_options_.site);
-    addHeader("Date", pgn_date);
+    addHeader("Date", match_.date);
     addHeader("Round", std::to_string(round_id));
     addHeader("White", white_player.config.name);
     addHeader("Black", black_player.config.name);

--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -1,6 +1,7 @@
 #include <pgn/pgn_builder.hpp>
 
 #include <iomanip>
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -38,7 +39,7 @@ PgnBuilder::PgnBuilder(const MatchData &match, const options::Tournament &tourna
 
     addHeader("Event", tournament_options.event_name);
     addHeader("Site", game_options_.site);
-    addHeader("Date", match_.date);
+    addHeader("Date", replace(match_.date.begin(), match_.date.end(), '-', '.'));
     addHeader("Round", std::to_string(round_id));
     addHeader("White", white_player.config.name);
     addHeader("Black", black_player.config.name);

--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -1,7 +1,6 @@
 #include <pgn/pgn_builder.hpp>
 
 #include <iomanip>
-#include <algorithm>
 #include <sstream>
 #include <string>
 #include <string_view>

--- a/src/types/match_data.hpp
+++ b/src/types/match_data.hpp
@@ -57,7 +57,7 @@ struct MatchData {
 
     explicit MatchData(std::string fen) : fen(std::move(fen)) {
         start_time = util::time::datetime("%Y-%m-%dT%H:%M:%S %z");
-        date       = util::time::datetime("%Y-%m-%d");
+        date       = util::time::datetime("%Y.%m.%d");
     }
 
     std::pair<PlayerInfo, PlayerInfo> players;


### PR DESCRIPTION
correct order is: event-site-date-round-white-black-result. Also reformat date to YYYY.MM.DD. cutechess also follows this standard. see below:

![Screenshot 2024-04-29 072444](https://github.com/Disservin/fast-chess/assets/155860115/e85bd604-3dbc-440d-95f2-8a17272d254a)
