### PR TITLE
fix: modify pgn

### DIFF
--- a/src/time/timecontrol.cpp
+++ b/src/time/timecontrol.cpp
@@ -21,6 +21,7 @@ TimeControl::TimeControl(const Limits &limits) : limits_(limits) {
     } else {
         time_left_ = 0;
     }
+    moves_left_ = limits_.moves;
 }
 
 std::chrono::milliseconds TimeControl::getTimeoutThreshold() const {

--- a/src/time/timecontrol.cpp
+++ b/src/time/timecontrol.cpp
@@ -19,7 +19,7 @@ TimeControl::TimeControl(const Limits &limits) : limits_(limits) {
     } else if (limits_.time != 0) {
         time_left_ = limits_.time;
     } else {
-        time_left_ = std::numeric_limits<std::int64_t>::max();
+        time_left_ = 0;
     }
 }
 

--- a/src/time/timecontrol.cpp
+++ b/src/time/timecontrol.cpp
@@ -61,10 +61,14 @@ std::ostream &operator<<(std::ostream &os, const TimeControl &tc) {
         os << std::setprecision(8) << std::noshowpoint << tc.limits_.fixed_time / 1000.0 << "/move";
         return os;
     }
-
+    
+    if (tc.moves == 0 && tc.time == 0 && tc.increment == 0 && tc.fixed_time == 0) {
+        os << "-";
+    }
+    
     if (tc.limits_.moves > 0) os << tc.limits_.moves << "/";
 
-    os << (tc.limits_.time / 1000.0);
+    if (tc.limits_.time > 0) os << (tc.limits_.time / 1000.0);
 
     if (tc.limits_.increment > 0) os << "+" << (tc.limits_.increment / 1000.0);
 

--- a/src/time/timecontrol.cpp
+++ b/src/time/timecontrol.cpp
@@ -62,7 +62,7 @@ std::ostream &operator<<(std::ostream &os, const TimeControl &tc) {
         return os;
     }
     
-    if (tc.moves == 0 && tc.time == 0 && tc.increment == 0 && tc.fixed_time == 0) {
+    if (tc.limits_.moves == 0 && tc.limits_.time == 0 && tc.limits_.increment == 0) {
         os << "-";
     }
     

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -65,7 +65,7 @@ struct Tournament {
 
     Sprt sprt = {};
 
-    std::string event_name = "Fast Chess";
+    std::string event_name = "Fast-Chess Tournament";
     std::string site       = "?";
 
     DrawAdjudication draw     = {};

--- a/tests/pgn_builder_test.cpp
+++ b/tests/pgn_builder_test.cpp
@@ -26,7 +26,7 @@ TEST_SUITE("PGN Builder Tests") {
         options::Tournament options;
         options.site = "localhost";
 
-        std::string expected = R"([Event "Fast Chess"]
+        std::string expected = R"([Event "Fast-Chess Tournament"]
 [Site "localhost"]
 [Round "1"]
 [White "engine1"]
@@ -34,7 +34,7 @@ TEST_SUITE("PGN Builder Tests") {
 [Result "1-0"]
 [FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"]
 [PlyCount "4"]
-[TimeControl "0"]
+[TimeControl "-"]
 
 1. e4 {+1.00/15, 1.321s} e5 {+1.23/15, 0.430s} 2. Nf3 {+1.45/16, 0.310s}
 Nf6 {+10.15/18, 1.821s, engine2 got checkmated} 1-0
@@ -67,7 +67,7 @@ Nf6 {+10.15/18, 1.821s, engine2 got checkmated} 1-0
         options::Tournament options;
         options.site = "localhost";
 
-        std::string expected = R"([Event "Fast Chess"]
+        std::string expected = R"([Event "Fast-Chess Tournament"]
 [Site "localhost"]
 [Round "1"]
 [White "engine1"]
@@ -75,7 +75,7 @@ Nf6 {+10.15/18, 1.821s, engine2 got checkmated} 1-0
 [Result "0-1"]
 [FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"]
 [PlyCount "4"]
-[TimeControl "0"]
+[TimeControl "-"]
 
 1. e4 {+1.00/15, 1.321s} e5 {+1.23/15, 0.430s} 2. Nf3 {+1.45/16, 0.310s}
 Nf6 {+10.15/18, 1.821s, engine1 got checkmated} 0-1
@@ -107,7 +107,7 @@ Nf6 {+10.15/18, 1.821s, engine1 got checkmated} 0-1
         options::Tournament options;
         options.site = "localhost";
 
-        std::string expected = R"([Event "Fast Chess"]
+        std::string expected = R"([Event "Fast-Chess Tournament"]
 [Site "localhost"]
 [Round "1"]
 [White "engine2"]
@@ -116,7 +116,7 @@ Nf6 {+10.15/18, 1.821s, engine1 got checkmated} 0-1
 [SetUp "1"]
 [FEN "r2qk2r/1bpp2pp/n3pn2/p2P1p2/1bP5/2N1BNP1/1PQ1PPBP/R3K2R b KQkq - 0 1"]
 [PlyCount "3"]
-[TimeControl "0"]
+[TimeControl "-"]
 
 1... O-O {+1.00/15, 1.321s} 2. O-O {+1.23/15, 0.430s}
 Nc5 {+1.45/16, 0.310s, aborted} *
@@ -150,7 +150,7 @@ Nc5 {+1.45/16, 0.310s, aborted} *
         options::Tournament options;
         options.site = "localhost";
 
-        std::string expected = R"([Event "Fast Chess"]
+        std::string expected = R"([Event "Fast-Chess Tournament"]
 [Site "localhost"]
 [Round "1"]
 [White "engine2"]
@@ -193,7 +193,7 @@ Nc5 {+1.45/16, 0.310s, aborted} *
         options::Tournament options;
         options.site = "localhost";
 
-        std::string expected = R"([Event "Fast Chess"]
+        std::string expected = R"([Event "Fast-Chess Tournament"]
 [Site "localhost"]
 [Round "1"]
 [White "engine2"]


### PR DESCRIPTION
display TimeControl["-"] when there is no time control specified to be consistent with the PGN standard and rename the default event to Fast-Chess Tournament as it makes more sense as an event name