### PR TITLE
refactor: send go infinite

### DIFF
--- a/src/matchmaking/player.hpp
+++ b/src/matchmaking/player.hpp
@@ -75,6 +75,10 @@ class Player {
                 input << " movestogo " << time_control_.getMovesLeft();
             }
         }
+       
+        if (engine.getConfig().limit.plies == 0 && engine.getConfig().limit.nodes == 0
+           && !time_control_.isTimed() && !time_control_.isFixedTime())
+            input << " infinite";
 
         return input.str();
     }


### PR DESCRIPTION
send "go infinite" if tc=inf and tc, st, plies, and depth arent specified. i think this is best practice than just sending "go" which doesnt have a defined behavior