### PR TITLE
refactor: individualize white and blacks time control uci input

### DIFF
--- a/src/matchmaking/player.hpp
+++ b/src/matchmaking/player.hpp
@@ -64,21 +64,13 @@ class Player {
             auto black = stm == chess::Color::WHITE ? enemy_tc : time_control_;
 
             if (time_control_.isTimed()) {
-               if (white.isTimed()) {
-                   input << " wtime " << white.getTimeLeft();
-               }
-               if (black.isTimed()) {
-                   input << " btime " << black.getTimeLeft();
-               }
+               if (white.isTimed()) input << " wtime " << white.getTimeLeft();
+               if (black.isTimed()) input << " btime " << black.getTimeLeft();
             }
 
             if (time_control_.isIncrement()) {
-               if (white.isIncrement()) {
-                   input << " winc " << white.getIncrement();
-               }
-               if (black.isIncrement()) {
-                   input << " binc " << black.getIncrement();
-               }
+               if (white.isIncrement()) input << " winc " << white.getIncrement();
+               if (black.isIncrement()) input << " binc " << black.getIncrement();
             }
 
             if (time_control_.isMoves()) {

--- a/src/matchmaking/player.hpp
+++ b/src/matchmaking/player.hpp
@@ -63,12 +63,20 @@ class Player {
             auto white = stm == chess::Color::WHITE ? time_control_ : enemy_tc;
             auto black = stm == chess::Color::WHITE ? enemy_tc : time_control_;
 
-            if (time_control_.isTimed()) {
-                input << " wtime " << white.getTimeLeft() << " btime " << black.getTimeLeft();
+            if (white.isTimed()) {
+                input << " wtime " << white.getTimeLeft();
             }
 
-            if (time_control_.isIncrement()) {
-                input << " winc " << white.getIncrement() << " binc " << black.getIncrement();
+            if (black.isTimed()) {
+                input << " btime " << black.getTimeLeft();
+            }
+
+            if (white.isIncrement()) {
+                input << " winc " << white.getIncrement();
+            }
+
+            if (black.isIncrement()) {
+                input << " binc " << black.getIncrement();
             }
 
             if (time_control_.isMoves()) {

--- a/src/matchmaking/player.hpp
+++ b/src/matchmaking/player.hpp
@@ -62,21 +62,23 @@ class Player {
         } else {
             auto white = stm == chess::Color::WHITE ? time_control_ : enemy_tc;
             auto black = stm == chess::Color::WHITE ? enemy_tc : time_control_;
-
-            if (white.isTimed()) {
-                input << " wtime " << white.getTimeLeft();
+           
+            if (time_control_.isTimed()) {
+               if (white.isTimed()) {
+                   input << " wtime " << white.getTimeLeft();
+               }
+               if (black.isTimed()) {
+                   input << " btime " << black.getTimeLeft();
+               }
             }
-
-            if (black.isTimed()) {
-                input << " btime " << black.getTimeLeft();
-            }
-
-            if (white.isIncrement()) {
-                input << " winc " << white.getIncrement();
-            }
-
-            if (black.isIncrement()) {
-                input << " binc " << black.getIncrement();
+           
+            if (time_control_.isIncrement()) {
+               if (white.isIncrement()) {
+                   input << " winc " << white.getIncrement();
+               }
+               if (black.isIncrement()) {
+                   input << " binc " << black.getIncrement();
+               }
             }
 
             if (time_control_.isMoves()) {

--- a/src/matchmaking/player.hpp
+++ b/src/matchmaking/player.hpp
@@ -62,7 +62,7 @@ class Player {
         } else {
             auto white = stm == chess::Color::WHITE ? time_control_ : enemy_tc;
             auto black = stm == chess::Color::WHITE ? enemy_tc : time_control_;
-           
+
             if (time_control_.isTimed()) {
                if (white.isTimed()) {
                    input << " wtime " << white.getTimeLeft();
@@ -71,7 +71,7 @@ class Player {
                    input << " btime " << black.getTimeLeft();
                }
             }
-           
+
             if (time_control_.isIncrement()) {
                if (white.isIncrement()) {
                    input << " winc " << white.getIncrement();

--- a/src/matchmaking/player.hpp
+++ b/src/matchmaking/player.hpp
@@ -64,13 +64,13 @@ class Player {
             auto black = stm == chess::Color::WHITE ? enemy_tc : time_control_;
 
             if (time_control_.isTimed()) {
-               if (white.isTimed()) input << " wtime " << white.getTimeLeft();
-               if (black.isTimed()) input << " btime " << black.getTimeLeft();
+                if (white.isTimed()) input << " wtime " << white.getTimeLeft();
+                if (black.isTimed()) input << " btime " << black.getTimeLeft();
             }
 
             if (time_control_.isIncrement()) {
-               if (white.isIncrement()) input << " winc " << white.getIncrement();
-               if (black.isIncrement()) input << " binc " << black.getIncrement();
+                if (white.isIncrement()) input << " winc " << white.getIncrement();
+                if (black.isIncrement()) input << " binc " << black.getIncrement();
             }
 
             if (time_control_.isMoves()) {


### PR DESCRIPTION
This patch is to cover cases where one engine uses a tc and the other doesnt. say if white uses tc of 10/0.1 while black uses fixed nodes=100000, the uci input for white now displays 
```go wtime 10000 winc 100``` 
instead of 
```go wtime 10000 btime 0 winc 100 binc 0```
i feel this makes more sense since the uci standard allows for only one sides tc to be input and this way the engine can assume its own values.