### PR TITLE
refactor: cutechess pgn time control format during time odds

### DIFF
--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -31,11 +31,6 @@ PgnBuilder::PgnBuilder(const MatchData &match, const options::Tournament &tourna
                                   ? match.players.first
                                   : match.players.second;
 
-    const auto tc = white_player.config.limit.tc == black_player.config.limit.tc
-                        ? str::to_string(white_player.config.limit.tc)
-                        : str::to_string(white_player.config.limit.tc) + "; " +
-                              str::to_string(black_player.config.limit.tc);
-
     addHeader("Event", tournament_options.event_name);
     addHeader("Site", game_options_.site);
     addHeader("Date", match_.date);
@@ -59,7 +54,13 @@ PgnBuilder::PgnBuilder(const MatchData &match, const options::Tournament &tourna
     addHeader("GameEndTime", match_.end_time);
     addHeader("PlyCount", std::to_string(match_.moves.size()));
     addHeader("Termination", convertMatchTermination(match_.termination));
-    addHeader("TimeControl", tc);
+    
+    if (white_player.config.limit.tc == black_player.config.limit.tc){
+        addHeader("TimeControl", str::to_string(white_player.config.limit.tc));
+    } else {
+        addHeader("WhiteTimeControl", str::to_string(white_player.config.limit.tc));
+        addHeader("BlackTimeControl", str::to_string(black_player.config.limit.tc));
+    }
 
     pgn_ << "\n";
     // add body

--- a/tests/pgn_builder_test.cpp
+++ b/tests/pgn_builder_test.cpp
@@ -202,7 +202,8 @@ Nc5 {+1.45/16, 0.310s, aborted} *
 [SetUp "1"]
 [FEN "r2qk2r/1bpp2pp/n3pn2/p2P1p2/1bP5/2N1BNP1/1PQ1PPBP/R3K2R b KQkq - 0 1"]
 [PlyCount "3"]
-[TimeControl "1/move; 0.2/move"]
+[WhiteTimeControl "1/move"]
+[BlackTimeControl "0.2/move"]
 
 1... O-O {+1.00/15, 1.321s} 2. O-O {+1.23/15, 0.430s}
 Nc5 {+1.45/16, 0.310s, aborted} *


### PR DESCRIPTION
i noticed in cutechess, during when white tc is different from black, they use WhiteTimeControl and BlackTimeControl tags. now the problem is these tags arent part of the pgn standard, so i dont know if we should abide by the standard or mimic cutechess. what do you think?