### PR TITLE
feat: accept -repeat 2 input

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -531,6 +531,7 @@ OptionsParser::OptionsParser(int argc, char const *argv[]) {
     addOption("recover", parseRecover);
     addOption("randomseed", parseRandomSeed);
     addOption("repeat", parseRepeat);
+    addOption("repeat 2", parseRepeat);
     addOption("variant", parseVariant);
     addOption("tournament", parseTournament);
     addOption("quick", parseQuick);


### PR DESCRIPTION
a lot of times cutechess users do -repeat 2 instead of -repeat, with this patch they now do the same thing instead of throwing an error.