### PR TITLE
fix: draw and resign counter now starts from odd plies only

### DIFF
--- a/src/matchmaking/match/match.cpp
+++ b/src/matchmaking/match/match.cpp
@@ -214,8 +214,8 @@ bool Match::playMove(Player& us, Player& opponent) {
         return false;
     }
 
-    draw_tracker_.update(us.engine.lastScore(), data_.moves.size() / 2, us.engine.lastScoreType());
-    resign_tracker_.update(us.engine.lastScore(), us.engine.lastScoreType());
+    draw_tracker_.update(us.engine.lastScore(), data_.moves.size() / 2, us.engine.lastScoreType(), board_.sideToMove());
+    resign_tracker_.update(us.engine.lastScore(), us.engine.lastScoreType(), board_.sideToMove());
     maxmoves_tracker_.update();
 
     const auto best_move = us.engine.bestmove();

--- a/src/matchmaking/match/match.hpp
+++ b/src/matchmaking/match/match.hpp
@@ -19,8 +19,10 @@ class DrawTracker {
 
     void update(const int score, const int move_count, engine::ScoreType score_type, chess::Color color) noexcept {
         if (move_count >= move_number_ && std::abs(score) <= draw_score &&
-            score_type == engine::ScoreType::CP && (color == chess::Color::WHITE || draw_moves > 0)) {
-            draw_moves++;
+            score_type == engine::ScoreType::CP) {
+            //start increment only from odd plies
+            if (color == chess::Color::WHITE || draw_moves > 0) 
+               draw_moves++;
         } else {
             draw_moves = 0;
         }
@@ -47,9 +49,11 @@ class ResignTracker {
     }
 
     void update(const int score, engine::ScoreType score_type, chess::Color color) noexcept {
-        if ((std::abs(score) >= resign_score && (color == chess::Color::WHITE || resign_moves > 0) 
-             && score_type == engine::ScoreType::CP) || score_type == engine::ScoreType::MATE) {
-            resign_moves++;
+        if ((std::abs(score) >= resign_score && score_type == engine::ScoreType::CP) 
+           || score_type == engine::ScoreType::MATE) {
+            //start increment only from odd plies
+            if (color == chess::Color::WHITE || resign_moves > 0)
+               resign_moves++;
         } else {
             resign_moves = 0;
         }

--- a/src/matchmaking/match/match.hpp
+++ b/src/matchmaking/match/match.hpp
@@ -47,8 +47,8 @@ class ResignTracker {
     }
 
     void update(const int score, engine::ScoreType score_type, chess::Color color) noexcept {
-        if ((std::abs(score) >= resign_score && score_type == engine::ScoreType::CP) ||
-            score_type == engine::ScoreType::MATE && (color == chess::Color::WHITE || resign_moves > 0)) {
+        if ((std::abs(score) >= resign_score && (color == chess::Color::WHITE || resign_moves > 0) 
+             && score_type == engine::ScoreType::CP) || score_type == engine::ScoreType::MATE) {
             resign_moves++;
         } else {
             resign_moves = 0;

--- a/src/matchmaking/match/match.hpp
+++ b/src/matchmaking/match/match.hpp
@@ -17,9 +17,9 @@ class DrawTracker {
         draw_score   = tournament_config.draw.score;
     }
 
-    void update(const int score, const int move_count, engine::ScoreType score_type) noexcept {
+    void update(const int score, const int move_count, engine::ScoreType score_type, chess::Color color) noexcept {
         if (move_count >= move_number_ && std::abs(score) <= draw_score &&
-            score_type == engine::ScoreType::CP) {
+            score_type == engine::ScoreType::CP && (color == chess::Color::WHITE || draw_moves > 0)) {
             draw_moves++;
         } else {
             draw_moves = 0;
@@ -46,9 +46,9 @@ class ResignTracker {
         move_count_  = tournament_config.resign.move_count;
     }
 
-    void update(const int score, engine::ScoreType score_type) noexcept {
+    void update(const int score, engine::ScoreType score_type, chess::Color color) noexcept {
         if ((std::abs(score) >= resign_score && score_type == engine::ScoreType::CP) ||
-            score_type == engine::ScoreType::MATE) {
+            score_type == engine::ScoreType::MATE && (color == chess::Color::WHITE || resign_moves > 0)) {
             resign_moves++;
         } else {
             resign_moves = 0;


### PR DESCRIPTION
prevents eval from being compared to eval of previous moves. tested it and seems to work ok.

partly solves https://github.com/Disservin/fast-chess/issues/335