### PR TITLE
fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ MKDIR	  := mkdir -p
 
 ifeq ($(OS), Windows_NT)
 	uname_S  := Windows
-	ifneq (,$(findstring g++,$(VARIABLE)))
+	ifeq ($(CXX),g++)
 		LDFLAGS = -static -static-libgcc -static-libstdc++ -Wl,--no-as-needed
 	else
 		LDFLAGS =


### PR DESCRIPTION
findstring doesnt seem to work

this patch doesnt fix for clang but works for mingw