### PR TITLE
fix: starting offset off by 1

### DIFF
--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -51,7 +51,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
 
 pgn::Opening OpeningBook::fetch() noexcept {
     static uint64_t opening_index = 0;
-    const auto idx                = start_ + opening_index++ + matchcount_ / games_;
+    const auto idx                = start_ - 1 + opening_index++ + matchcount_ / games_;
     const auto book_size          = std::holds_alternative<epd_book>(book_)
                                         ? std::get<epd_book>(book_).size()
                                         : std::get<pgn_book>(book_).size();

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -251,7 +251,9 @@ void parseOpening(int &i, int argc, char const *argv[], ArgumentData &argument_d
         } else if (key == "plies") {
             argument_data.tournament_options.opening.plies = std::stoi(value);
         } else if (key == "start") {
-            argument_data.tournament_options.opening.start = std::stoi(value);
+            argument_data.tournament_options.opening.start = std::stoi(value) - 1;
+            if (argument_data.tournament_options.opening.start < 1)
+                throw std::runtime_error("Starting offset must be at least 1!");
         } else {
             OptionsParser::throwMissing("openings", key, value);
         }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -251,7 +251,7 @@ void parseOpening(int &i, int argc, char const *argv[], ArgumentData &argument_d
         } else if (key == "plies") {
             argument_data.tournament_options.opening.plies = std::stoi(value);
         } else if (key == "start") {
-            argument_data.tournament_options.opening.start = std::stoi(value) - 1;
+            argument_data.tournament_options.opening.start = std::stoi(value);
             if (argument_data.tournament_options.opening.start < 1)
                 throw std::runtime_error("Starting offset must be at least 1!");
         } else {

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -12,7 +12,7 @@ struct Opening {
     FormatType format = FormatType::NONE;
     OrderType order   = OrderType::RANDOM;
     int plies         = -1;
-    int start         = 0;
+    int start         = 1;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Opening, file, format, order, plies, start)
 


### PR DESCRIPTION
cutechess starts its starting offset from 1 while fastchess currently starts from 0 (cutechess start=1 is fastchess start=0 and etc...), this patch makes them consistent by having fastchess also start from 1.