### PR TITLE
refactor: clearer compile instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Building Fast-Chess from source is straightforward. Just follow these steps:
 
 1. Clone the repository `git clone https://github.com/Disservin/fast-chess.git`
 2. Navigate to the fast-chess directory `cd fast-chess`
-3. Build the executable `make -j` for GCC and `make -j CXX=clang++` for clang
+3. Build the executable `make -j` for GCC and `make -j CXX=clang++` for Clang
 
 ### Download the latest release
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ short time controls (0.2+0.002s), it exhibits minimal timeout issues, with only
 
 Building Fast-Chess from source is straightforward. Just follow these steps:
 
-1. Clone the repository `git clone https://github.com/Disservin/fast-chess.git`
+1. Clone the repository `git clone https://github.com/Disservin/fast-chess.git
 2. Navigate to the fast-chess directory `cd fast-chess`
-3. Build the executable `make -j`
+3. Build the executable `make -j` for gcc and `make -j CXX=clang++` for clang
 
 ### Download the latest release
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Building Fast-Chess from source is straightforward. Just follow these steps:
 
 1. Clone the repository `git clone https://github.com/Disservin/fast-chess.git`
 2. Navigate to the fast-chess directory `cd fast-chess`
-3. Build the executable `make -j` for gcc and `make -j CXX=clang++` for clang
+3. Build the executable `make -j` for GCC and `make -j CXX=clang++` for clang
 
 ### Download the latest release
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ short time controls (0.2+0.002s), it exhibits minimal timeout issues, with only
 
 Building Fast-Chess from source is straightforward. Just follow these steps:
 
-1. Clone the repository `git clone https://github.com/Disservin/fast-chess.git
+1. Clone the repository `git clone https://github.com/Disservin/fast-chess.git`
 2. Navigate to the fast-chess directory `cd fast-chess`
 3. Build the executable `make -j` for gcc and `make -j CXX=clang++` for clang
 


### PR DESCRIPTION
prevents the usage of CXX=clang