### PR TITLE
refactor: change "finished tournament." to "finished match"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char const *argv[]) {
         Logger::log<Logger::Level::TRACE>("Starting tournament...");
         tour.start();
 
-        Logger::log<Logger::Level::INFO>("Finished tournament.");
+        Logger::log<Logger::Level::INFO>("Finished match");
     }
 
     stopProcesses();


### PR DESCRIPTION
fishtest uses that string to exit, see: https://github.com/official-stockfish/fishtest/blob/ee4cde1e36768ad573b1ea11b3e76c0376b0e2f6/worker/games.py#L939