### PR TITLE
refactor: flush logger output

### DIFF
--- a/src/util/logger/logger.hpp
+++ b/src/util/logger/logger.hpp
@@ -35,7 +35,7 @@ class Logger {
         ((ss << " " << std::forward<Args>(args)), ...);
         ss << "\n";
 
-        std::cout << ss.str();
+        std::cout << ss.str() << std::flush;
 
         if (!should_log_) {
             return;


### PR DESCRIPTION
this is what chatgpt says at least
```
Immediate Output: If you need to ensure that output appears immediately, such as in logging or real-time user interaction scenarios, std::flush can be useful. For example, after printing a prompt to the user, you might want to flush the stream to ensure the prompt appears right away:
```