### PR TITLE
fix: allow policy=round command for openings

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -257,7 +257,7 @@ void parseOpening(int &i, int argc, char const *argv[], ArgumentData &argument_d
             if (argument_data.tournament_options.opening.start < 1)
                 throw std::runtime_error("Starting offset must be at least 1!");
         } else if (key == "policy") {
-            if (value != "default")
+            if (value != "default" && value != "round")
                 throw std::runtime_error("Error; Unsupported opening book policy");
         } else {
             OptionsParser::throwMissing("openings", key, value);


### PR DESCRIPTION
apparently policy=default and policy=round does pretty much the same thing when the number of engines is 2