### PR TITLE
refactor: improve compatibility with supported cutechess command

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -266,7 +266,14 @@ void parsePgnOut(const std::vector<std::string> &params, ArgumentData &argument_
         });
     } catch (const std::exception &e) {
         // try to read as cutechess pgnout
-        parseValue(params, argument_data.tournament_options.pgn.file);
+        std::string val = readUntilDash(i, argc, argv);
+        if (str_utils::contains(val, " ")) {
+            const auto string_vector = str_utils::splitString(val, ' ');
+            argument_data.tournament_options.pgn.file = string_vector[0];
+            if (str_utils::contains(val, " min")) argument_data.tournament_options.pgn.min = true;
+        } else {
+            argument_data.tournament_options.pgn.file = val;
+        }
     }
 }
 
@@ -318,7 +325,7 @@ void parseOpening(const std::vector<std::string> &params, ArgumentData &argument
             if (argument_data.tournament_options.opening.start < 1)
                 throw std::runtime_error("Starting offset must be at least 1!");
         } else if (key == "policy") {
-            if (value != "default")
+            if (value != "round")
                 throw std::runtime_error("Error; Unsupported opening book policy");
         } else {
             OptionsParser::throwMissing("openings", key, value);

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -270,7 +270,8 @@ void parsePgnOut(const std::vector<std::string> &params, ArgumentData &argument_
         if (str_utils::contains(val, " ")) {
             const auto string_vector = str_utils::splitString(val, ' ');
             argument_data.tournament_options.pgn.file = string_vector[0];
-            if (str_utils::contains(val, " min")) argument_data.tournament_options.pgn.min = true;
+            if (std::find(params.begin(), params.end(), "min") != params.end())
+                argument_data.tournament_options.pgn.min = true;
         } else {
             argument_data.tournament_options.pgn.file = val;
         }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -267,8 +267,7 @@ void parsePgnOut(const std::vector<std::string> &params, ArgumentData &argument_
     } catch (const std::exception &e) {
         // try to read as cutechess pgnout
         argument_data.tournament_options.pgn.file = params[0];
-        if (std::find(params.begin(), params.end(), "min") != params.end())
-            argument_data.tournament_options.pgn.min = true;
+        argument_data.tournament_options.pgn.min = std::find(params.begin(), params.end(), "min") != params.end();
     }
 }
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -266,7 +266,7 @@ void parsePgnOut(const std::vector<std::string> &params, ArgumentData &argument_
         });
     } catch (const std::exception &e) {
         // try to read as cutechess pgnout
-        std::string val = readUntilDash(i, argc, argv);
+        std::string val = concat(params);
         if (str_utils::contains(val, " ")) {
             const auto string_vector = str_utils::splitString(val, ' ');
             argument_data.tournament_options.pgn.file = string_vector[0];

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -266,15 +266,9 @@ void parsePgnOut(const std::vector<std::string> &params, ArgumentData &argument_
         });
     } catch (const std::exception &e) {
         // try to read as cutechess pgnout
-        std::string val = concat(params);
-        if (str_utils::contains(val, " ")) {
-            const auto string_vector = str_utils::splitString(val, ' ');
-            argument_data.tournament_options.pgn.file = string_vector[0];
-            if (std::find(params.begin(), params.end(), "min") != params.end())
-                argument_data.tournament_options.pgn.min = true;
-        } else {
-            argument_data.tournament_options.pgn.file = val;
-        }
+        argument_data.tournament_options.pgn.file = params[0];
+        if (std::find(params.begin(), params.end(), "min") != params.end())
+            argument_data.tournament_options.pgn.min = true;
     }
 }
 


### PR DESCRIPTION
adds support for `-pgnout FILE min` and allows `policy=round` input which fastchess has support for