### PR TITLE
fix: make movenumber consistent with cutechess

### DIFF
--- a/src/matchmaking/match/match.hpp
+++ b/src/matchmaking/match/match.hpp
@@ -20,7 +20,7 @@ class DrawTracker {
     void update(const int score, const int move_count, engine::ScoreType score_type,
                 const int hmvc) noexcept {
         if (hmvc == 0) draw_moves = 0;
-        if (move_count >= move_number_ && std::abs(score) <= draw_score &&
+        if (move_count - 1 >= move_number_ && std::abs(score) <= draw_score &&
             score_type == engine::ScoreType::CP) {
             draw_moves++;
         } else {


### PR DESCRIPTION
cutechess uses board->plycount() / 2 for its movenumber, which is equivalent to board_.fullmovenumber - 1 in fastchess