### PR TITLE
feat: throw error for invalid sprt config

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -298,6 +298,8 @@ void parseOpening(const std::vector<std::string> &params, ArgumentData &argument
 
 void parseSprt(const std::vector<std::string> &params, ArgumentData &argument_data) {
     parseDashOptions(params, [&](const std::string &key, const std::string &value) {
+        argument_data.tournament_options.sprt.enabled = true;
+      
         if (argument_data.tournament_options.rounds == 0) {
             argument_data.tournament_options.rounds = 500000;
         }

--- a/src/matchmaking/output/output_cutechess.hpp
+++ b/src/matchmaking/output/output_cutechess.hpp
@@ -56,7 +56,7 @@ class Cutechess : public IOutput {
     }
 
     void printSprt(const SPRT& sprt, const Stats& stats) override {
-        if (sprt.isValid()) {
+        if (sprt.isEnabled()) {
             std::stringstream ss;
 
             ss << "LLR: " << std::fixed << std::setprecision(2)

--- a/src/matchmaking/output/output_fastchess.hpp
+++ b/src/matchmaking/output/output_fastchess.hpp
@@ -85,7 +85,7 @@ class Fastchess : public IOutput {
     }
 
     void printSprt(const SPRT& sprt, const Stats& stats) override {
-        if (sprt.isValid()) {
+        if (sprt.isEnabled()) {
             double llr = sprt.getLLR(stats, report_penta_);
 
             std::stringstream ss;

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -9,10 +9,9 @@
 
 namespace fast_chess {
 
-SPRT::SPRT(double alpha, double beta, double elo0, double elo1, std::string model) {
-    valid_ = alpha != 0.0 && beta != 0.0 && elo0 < elo1 
-             && (model == "normalized" || model == "bayesian" || model == "logistic");
-    if (isValid()) {
+SPRT::SPRT(double alpha, double beta, double elo0, double elo1, std::string model, bool enabled) {
+    enabled_ = enabled;
+    if (enabled_) {
         lower_ = std::log(beta / (1 - alpha));
         upper_ = std::log((1 - beta) / alpha);
 
@@ -22,9 +21,6 @@ SPRT::SPRT(double alpha, double beta, double elo0, double elo1, std::string mode
         model_ = model;
 
         Logger::log<Logger::Level::INFO>("Initialized valid SPRT configuration.");
-    } else if (!(alpha == 0.0 && beta == 0.0 && elo0 == 0.0 && elo1 == 0.0)) {
-        Logger::log<Logger::Level::INFO>("No valid SPRT configuration was found!");
-    }
 }
 
 double SPRT::leloToScore(double lelo) noexcept { return 1 / (1 + std::pow(10, (-lelo / 400))); }
@@ -53,7 +49,7 @@ double SPRT::getLLR(const Stats& stats, bool penta) const noexcept {
 }
 
 double SPRT::getLLR(int win, int draw, int loss) const noexcept {
-    if (!valid_) return 0.0;
+    if (!enabled_) return 0.0;
 
     const double games = win + draw + loss;
     if (games == 0) return 0.0;
@@ -95,7 +91,7 @@ double SPRT::getLLR(int win, int draw, int loss) const noexcept {
 
 double SPRT::getLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int penta_LD,
                     int penta_LL) const noexcept {
-    if (!valid_) return 0.0;
+    if (!enabled_) return 0.0;
 
     const double pairs = penta_WW + penta_WD + penta_WL + penta_DD + penta_LD + penta_LL;
     if (pairs == 0) return 0.0;
@@ -140,7 +136,7 @@ double SPRT::getLLR(int penta_WW, int penta_WD, int penta_WL, int penta_DD, int 
 }
 
 SPRTResult SPRT::getResult(double llr) const noexcept {
-    if (!valid_) return SPRT_CONTINUE;
+    if (!enabled_) return SPRT_CONTINUE;
 
     if (llr >= upper_)
         return SPRT_H0;
@@ -165,6 +161,6 @@ std::string SPRT::getElo() const noexcept {
     return ss.str();
 }
 
-bool SPRT::isValid() const noexcept { return valid_; }
+bool SPRT::isValid() const noexcept { return enabled_; }
 
 }  // namespace fast_chess

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -21,6 +21,7 @@ SPRT::SPRT(double alpha, double beta, double elo0, double elo1, std::string mode
         model_ = model;
 
         Logger::log<Logger::Level::INFO>("Initialized valid SPRT configuration.");
+    }
 }
 
 double SPRT::leloToScore(double lelo) noexcept { return 1 / (1 + std::pow(10, (-lelo / 400))); }

--- a/src/matchmaking/sprt/sprt.cpp
+++ b/src/matchmaking/sprt/sprt.cpp
@@ -161,6 +161,6 @@ std::string SPRT::getElo() const noexcept {
     return ss.str();
 }
 
-bool SPRT::isValid() const noexcept { return enabled_; }
+bool SPRT::isEnabled() const noexcept { return enabled_; }
 
 }  // namespace fast_chess

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -12,7 +12,7 @@ class SPRT {
    public:
     SPRT() = default;
 
-    SPRT(double alpha, double beta, double elo0, double elo1, std::string model);
+    SPRT(double alpha, double beta, double elo0, double elo1, std::string model, bool enabled);
 
     [[nodiscard]] bool isEnabled() const noexcept;
 

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -14,6 +14,8 @@ class SPRT {
 
     SPRT(double alpha, double beta, double elo0, double elo1, std::string model);
 
+    [[nodiscard]] bool isEnabled() const noexcept;
+
     [[nodiscard]] static double leloToScore(double lelo) noexcept;
     [[nodiscard]] static double bayeseloToScore(double bayeselo, double drawelo) noexcept;
     [[nodiscard]] static double neloToScoreWDL(double nelo, double stdDeviation) noexcept;

--- a/src/matchmaking/sprt/sprt.hpp
+++ b/src/matchmaking/sprt/sprt.hpp
@@ -14,8 +14,6 @@ class SPRT {
 
     SPRT(double alpha, double beta, double elo0, double elo1, std::string model);
 
-    [[nodiscard]] bool isValid() const noexcept;
-
     [[nodiscard]] static double leloToScore(double lelo) noexcept;
     [[nodiscard]] static double bayeseloToScore(double bayeselo, double drawelo) noexcept;
     [[nodiscard]] static double neloToScoreWDL(double nelo, double stdDeviation) noexcept;
@@ -36,7 +34,7 @@ class SPRT {
     double elo0_ = 0.0;
     double elo1_ = 0.0;
 
-    bool valid_           = false;
+    bool enabled_         = false;
     std::string model_    = "normalized";
 };
 

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -140,7 +140,7 @@ void RoundRobin::create() {
 }
 
 void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine_configs) {
-    if (!sprt_.isValid()) return;
+    if (!sprt_.isEnabled()) return;
 
     const auto stats = result_.getStats(engine_configs[0].name, engine_configs[1].name);
     const auto llr   = sprt_.getLLR(stats, tournament_options_.report_penta);

--- a/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -16,7 +16,7 @@ RoundRobin::RoundRobin(const options::Tournament& tournament_config,
     // Initialize the SPRT test
     sprt_ = SPRT(tournament_options_.sprt.alpha, tournament_options_.sprt.beta,
                  tournament_options_.sprt.elo0, tournament_options_.sprt.elo1,
-                 tournament_options_.sprt.model);
+                 tournament_options_.sprt.model, tournament_options_.sprt.enabled);
 }
 
 void RoundRobin::start() {

--- a/src/matchmaking/tournament/tournament_manager.cpp
+++ b/src/matchmaking/tournament/tournament_manager.cpp
@@ -45,10 +45,23 @@ options::Tournament TournamentManager::fixConfig(options::Tournament config) {
 
     if (config.report_penta && config.games != 2) config.report_penta = false;
 
-    if (config.sprt.model == "bayesian" && config.report_penta) {
-        Logger::log<Logger::Level::WARN>(
-            "Warning: Bayesian SPRT model not available with pentanomial statistics. Disabling pentanomial reports...");
-        config.report_penta = false;
+    // throw error for invalid sprt config
+    if (config.sprt.enabled) {
+        if (config.sprt.elo0 >= config.sprt.elo1) {
+            throw std::runtime_error("Error; SPRT: elo0 must be less than elo1!");
+        } else if (config.sprt.alpha <= 0 || config.sprt.alpha >= 1) {
+            throw std::runtime_error("Error; SPRT: alpha must be a decimal number between 0 and 1!");
+        } else if (config.sprt.beta <= 0 || config.sprt.beta >= 1) {
+            throw std::runtime_error("Error; SPRT: beta must be a decimal number between 0 and 1!");
+        } else if (config.sprt.model != "normalized" && config.sprt.model != "bayesian" && config.sprt.model != "logistic") {
+            throw std::runtime_error("Error; SPRT: invalid SPRT model!");
+        }
+
+        if (config.sprt.model == "bayesian" && config.report_penta) {
+            Logger::log<Logger::Level::WARN>(
+                "Warning: Bayesian SPRT model not available with pentanomial statistics. Disabling pentanomial reports...");
+            config.report_penta = false;
+        }
     }
 
     config.concurrency =

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -44,7 +44,7 @@ struct Sprt {
     // bayesian model only available when -penta report=false
     std::string model    = "normalized";
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Sprt, alpha, beta, elo0, elo1, model)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Sprt, alpha, beta, elo0, elo1, model, enabled)
 
 struct DrawAdjudication {
     int move_number = 0;

--- a/src/types/tournament_options.hpp
+++ b/src/types/tournament_options.hpp
@@ -35,6 +35,7 @@ struct Epd {
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Epd, file)
 
 struct Sprt {
+    bool enabled         = false;
     double alpha         = 0.0;
     double beta          = 0.0;
     double elo0          = 0.0;

--- a/tests/sprt_test.cpp
+++ b/tests/sprt_test.cpp
@@ -9,70 +9,70 @@ using namespace fast_chess;
 TEST_SUITE("SPRT") {
     TEST_CASE("normalized trinomial 1") {
         Stats stats(36433, 36027, 68692);
-        SPRT sprt(0.05, 0.05, 0, 2, "normalized");
+        SPRT sprt(0.05, 0.05, 0, 2, "normalized", true);
 
         CHECK(sprt.getLLR(stats, false) == doctest::Approx(0.92).epsilon(0.01));
     }
 
     TEST_CASE("normalized trinomial 2") {
         Stats stats(10871, 10650, 20431);
-        SPRT sprt(0.05, 0.05, -1.75, 0.25, "normalized");
+        SPRT sprt(0.05, 0.05, -1.75, 0.25, "normalized", true);
 
         CHECK(sprt.getLLR(stats, false) == doctest::Approx(2.30).epsilon(0.01));
     }
 
     TEST_CASE("logistic trinomial 1") {
         Stats stats(21404, 21184, 40708);
-        SPRT sprt(0.05, 0.05, 0.5, 2.5, "logistic");
+        SPRT sprt(0.05, 0.05, 0.5, 2.5, "logistic", true);
 
         CHECK(sprt.getLLR(stats, false) == doctest::Approx(-1.57).epsilon(0.01));
     }
 
     TEST_CASE("logistic trinomial 2") {
         Stats stats(57433, 57030, 106593);
-        SPRT sprt(0.05, 0.05, 0, 2, "logistic");
+        SPRT sprt(0.05, 0.05, 0, 2, "logistic", true);
 
         CHECK(sprt.getLLR(stats, false) == doctest::Approx(-2.59).epsilon(0.01));
     }
 
     TEST_CASE("bayesian trinomial 1") {
         Stats stats(68965, 68526, 128429);
-        SPRT sprt(0.05, 0.05, 0, 2, "bayesian");
+        SPRT sprt(0.05, 0.05, 0, 2, "bayesian", true);
 
         CHECK(sprt.getLLR(stats, false) == doctest::Approx(-1.26).epsilon(0.01));
     }
 
     TEST_CASE("bayesian trinomial 2") {
         Stats stats(21629, 21484, 41111);
-        SPRT sprt(0.05, 0.05, 0.5, 2.5, "bayesian");
+        SPRT sprt(0.05, 0.05, 0.5, 2.5, "bayesian", true);
 
         CHECK(sprt.getLLR(stats, false) == doctest::Approx(-1.13).epsilon(0.01));
     }
 
     TEST_CASE("normalized pentanomial 1") {
         Stats stats(365, 16618, 36029, 200, 16974, 390);
-        SPRT sprt(0.05, 0.05, 0, 2, "normalized");
+        SPRT sprt(0.05, 0.05, 0, 2, "normalized", true);
 
         CHECK(sprt.getLLR(stats, true) == doctest::Approx(2.25).epsilon(0.01));
     }
 
     TEST_CASE("normalized pentanomial 2") {
         Stats stats(127, 4883, 10311, 401, 5150, 104);
-        SPRT sprt(0.05, 0.05, -1.75, 0.25, "normalized");
+        SPRT sprt(0.05, 0.05, -1.75, 0.25, "normalized", true);
 
         CHECK(sprt.getLLR(stats, true) == doctest::Approx(3.01).epsilon(0.01));
     }
 
     TEST_CASE("logistic pentanomial 1") {
         Stats stats(223, 9863, 20279, 1000, 10037, 246);
-        SPRT sprt(0.05, 0.05, 0.5, 2.5, "logistic");
+        SPRT sprt(0.05, 0.05, 0.5, 2.5, "logistic", true);
 
         CHECK(sprt.getLLR(stats, true) == doctest::Approx(-3.07).epsilon(0.01));
     }
 
     TEST_CASE("logistic pentanomial 2") {
         Stats stats(871, 26175, 55003, 980, 26678, 821);
-        SPRT sprt(0.05, 0.05, 0, 2, "logistic");
+        SPRT sprt(0.05, 0.05, 0, 2, "logistic", true);
 
         CHECK(sprt.getLLR(stats, true) == doctest::Approx(-4.98).epsilon(0.01));
     }


### PR DESCRIPTION
invalid sprt config now throws error instead of just a warning. it is better this way as the warning can easily be missed and the user would have realized too late, as can be seen here: https://discord.com/channels/435943710472011776/882956631514689597/1247264312066703420

already tested this patch and it works well
fix https://github.com/Disservin/fast-chess/issues/431