### PR TITLE
refactor: reduce memory usage when using large books

### DIFF
--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -62,8 +62,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              }
         }
         
-        if (epd_.size() > rounds_) {
-            epd_.erase(epd_.begin() + static_cast<std::size_t>(rounds_), epd_.end());
+        if (epd_.size() > static_cast<std::size_t>(rounds_)) {
+            epd_.erase(epd_.begin() + rounds_, epd_.end());
             epd_.shrink_to_fit();
         }
 

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -62,7 +62,7 @@ pgn::Opening OpeningBook::fetch() noexcept {
 
     // - 1 because start starts at 1 in the opening options
     const auto idx       = start_ - 1 + opening_index++ + matchcount_ / games_;
-    const auto book_size = std::max(epd_.size(), pgn_.size());
+    const auto book_size = epd_.size() + pgn_.size();
 
     if (book_size == 0) {
         return {chess::constants::STARTPOS, {}};

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -24,7 +24,13 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     if (type == FormatType::PGN) {
         pgn_ = pgn::PgnReader(file, plies_).getOpenings();
         
-        if (order_ == OrderType::RANDOM) shuffle(pgn_);
+        if (order_ == OrderType::RANDOM) {
+             for (std::size_t i = 0; i + 2 <= pgn_.size(); i++) {
+                 auto rand     = util::random::mersenne_rand();
+                 std::size_t j = i + (rand % (pgn_.size() - i));
+                 std::swap(vec[i], vec[j]);
+             }
+        }
         
         if (pgn_.size() > games_ * rounds_) {
             pgn_.erase(pgn_.begin() + games_ * rounds_, pgn_.end());
@@ -45,7 +51,13 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
 
         openingFile.close();
 
-        if (order_ == OrderType::RANDOM) shuffle(epd_);
+        if (order_ == OrderType::RANDOM) {
+             for (std::size_t i = 0; i + 2 <= epd_.size(); i++) {
+                 auto rand     = util::random::mersenne_rand();
+                 std::size_t j = i + (rand % (epd_.size() - i));
+                 std::swap(vec[i], vec[j]);
+             }
+        }
         
         if (epd_.size() > games_ * rounds_) {
             epd_.erase(epd_.begin() + games_ * rounds_, epd_.end());

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -24,7 +24,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     if (type == FormatType::PGN) {
         pgn_ = pgn::PgnReader(file, plies_).getOpenings();
         
-        if (order_ == OrderType::RANDOM) shuffle(epd);
+        if (order_ == OrderType::RANDOM) shuffle(pgn_);
         
         if (pgn.size() > games_ * rounds_) {
             pgn_.erase(pgn_.begin() + games_ * rounds_, pgn_.end());
@@ -45,7 +45,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
 
         openingFile.close();
 
-        if (order_ == OrderType::RANDOM) shuffle(pgn);
+        if (order_ == OrderType::RANDOM) shuffle(epd_);
         
         if (epd_.size() > games_ * rounds_) {
             epd_.erase(epd_.begin() + games_ * rounds_, epd_.end());

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -24,6 +24,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     if (type == FormatType::PGN) {
         pgn_ = pgn::PgnReader(file, plies_).getOpenings();
         
+        if (order_ == OrderType::RANDOM) shuffle(type);
+        
         if (pgn.size() > games_ * rounds_) {
             pgn_.erase(pgn_.begin() + games_ * rounds_, pgn_.end());
         }
@@ -42,6 +44,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         }
 
         openingFile.close();
+
+        if (order_ == OrderType::RANDOM) shuffle(type);
         
         if (epd_.size() > games_ * rounds_) {
             epd_.erase(epd_.begin() + games_ * rounds_, epd_.end());
@@ -51,8 +55,6 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
             throw std::runtime_error("No openings found in EPD file: " + file);
         }
     }
-
-    if (order_ == OrderType::RANDOM && type != FormatType::NONE) shuffle();
 }
 
 pgn::Opening OpeningBook::fetch() noexcept {

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -22,7 +22,15 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     }
 
     if (type == FormatType::PGN) {
-        book_ = pgn::PgnReader(file, plies_).getOpenings();
+        std::vector<pgn::Opening> pgn;
+
+        pgn = pgn::PgnReader(file, plies_).getOpenings();
+        
+        if (pgn.size() > games_ * rounds_) {
+            epd.erase(pgn.begin() + games_ * rounds_, pgn.end());
+        }
+        
+        book_ = pgn;
 
         if (std::get<pgn_book>(book_).empty()) {
             throw std::runtime_error("No openings found in PGN file: " + file);

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -21,7 +21,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         return;
     }
 
-    std::size_t total_games = static_cast<std::size_t>(games_ * rounds_)
+    std::size_t total_games = static_cast<std::size_t>(games_ * rounds_);
     
     if (type == FormatType::PGN) {
         pgn_ = pgn::PgnReader(file, plies_).getOpenings();

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -26,7 +26,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         
         if (order_ == OrderType::RANDOM) shuffle(pgn_);
         
-        if (pgn.size() > games_ * rounds_) {
+        if (pgn_.size() > games_ * rounds_) {
             pgn_.erase(pgn_.begin() + games_ * rounds_, pgn_.end());
         }
 

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -49,7 +49,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     if (order_ == OrderType::RANDOM && type != FormatType::NONE) shuffle();
 
     if (book_.size() > 8) {
-        book_.erase(vec.begin() + 8, vec.end());
+        book_.erase(book_.begin() + 8, book_.end());
     }
 }
 

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -27,7 +27,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         pgn_ = pgn::PgnReader(file, plies_).getOpenings();
 
         // Fisher-Yates / Knuth shuffle
-        if (order_ == OrderType::RANDOM) {
+        if (order_ == OrderType::RANDOM && !pgn_.empty()) {
              for (std::size_t i = 0; i + 2 <= pgn_.size(); i++) {
                  auto rand     = util::random::mersenne_rand();
                  std::size_t j = i + (rand % (pgn_.size() - i));
@@ -55,7 +55,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         openingFile.close();
 
         // Fisher-Yates / Knuth shuffle
-        if (order_ == OrderType::RANDOM) {
+        if (order_ == OrderType::RANDOM && !epd_.empty()) {
              for (std::size_t i = 0; i + 2 <= epd_.size(); i++) {
                  auto rand     = util::random::mersenne_rand();
                  std::size_t j = i + (rand % (epd_.size() - i));

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -62,9 +62,7 @@ pgn::Opening OpeningBook::fetch() noexcept {
 
     // - 1 because start starts at 1 in the opening options
     const auto idx       = start_ - 1 + opening_index++ + matchcount_ / games_;
-    const auto book_size = std::holds_alternative<epd_book>(book_)
-                               ? std::get<epd_book>(book_).size()
-                               : std::get<pgn_book>(book_).size();
+    const auto book_size = std::max(epd_.size(), pgn_.size());
 
     if (book_size == 0) {
         return {chess::constants::STARTPOS, {}};

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -27,8 +27,6 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         if (pgn.size() > games_ * rounds_) {
             pgn_.erase(pgn_.begin() + games_ * rounds_, pgn_.end());
         }
-        
-        book_ = pgn;
 
         if (pgn_.empty()) {
             throw std::runtime_error("No openings found in PGN file: " + file);

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -47,6 +47,10 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     }
 
     if (order_ == OrderType::RANDOM && type != FormatType::NONE) shuffle();
+
+    if (book_.size() > 8) {
+        book_.erase(vec.begin() + 8, vec.end());
+    }
 }
 
 pgn::Opening OpeningBook::fetch() noexcept {

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -8,10 +8,11 @@
 namespace fast_chess::book {
 
 OpeningBook::OpeningBook(const options::Tournament& tournament) {
-    start_ = tournament.opening.start;
-    games_ = tournament.games;
-    order_ = tournament.opening.order;
-    plies_ = tournament.opening.plies;
+    start_  = tournament.opening.start;
+    games_  = tournament.games;
+    rounds_ = tournament.rounds;
+    order_  = tournament.opening.order;
+    plies_  = tournament.opening.plies;
     setup(tournament.opening.file, tournament.opening.format);
 }
 
@@ -38,7 +39,11 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         }
 
         openingFile.close();
-
+        
+        if (epd.size() > games_ * rounds_) {
+            epd.erase(epd.begin() + games_ * rounds_, epd.end());
+        }
+        
         book_ = epd;
 
         if (std::get<epd_book>(book_).empty()) {
@@ -47,10 +52,6 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     }
 
     if (order_ == OrderType::RANDOM && type != FormatType::NONE) shuffle();
-
-    if (book_.size() > 8) {
-        book_.erase(book_.begin() + 8, book_.end());
-    }
 }
 
 pgn::Opening OpeningBook::fetch() noexcept {

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -37,6 +37,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
 
         if (pgn_.size() > total_games) {
             pgn_.erase(pgn_.begin() + total_games, pgn_.end());
+            pgn_.shrink_to_fit();
         }
 
         if (pgn_.empty()) {
@@ -65,6 +66,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         
         if (epd_.size() > total_games) {
             epd_.erase(epd_.begin() + total_games, epd_.end());
+            epd_.shrink_to_fit();
         }
 
         if (epd_.empty()) {

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -31,7 +31,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              for (std::size_t i = 0; i + 2 <= pgn_.size(); i++) {
                  auto rand     = util::random::mersenne_rand();
                  std::size_t j = i + (rand % (pgn_.size() - i));
-                 std::swap(vec[i], vec[j]);
+                 std::swap(pgn_[i], pgn_[j]);
              }
         }
 
@@ -59,7 +59,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              for (std::size_t i = 0; i + 2 <= epd_.size(); i++) {
                  auto rand     = util::random::mersenne_rand();
                  std::size_t j = i + (rand % (epd_.size() - i));
-                 std::swap(vec[i], vec[j]);
+                 std::swap(epd_[i], epd_[j]);
              }
         }
         

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -33,8 +33,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              }
         }
 
-        if (pgn_.size() > static_cast<std::size_t>(start_ + rounds_ - 1)) {
-            pgn_.erase(pgn_.begin() + (start_ + rounds_ - 1), pgn_.end());
+        if (pgn_.size() > static_cast<std::size_t>(start_ + rounds_ - 1 + matchcount_ / games_)) {
+            pgn_.erase(pgn_.begin() + (start_ + rounds_ - 1 + matchcount_ / games_), pgn_.end());
             pgn_.shrink_to_fit();
         }
 
@@ -62,8 +62,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              }
         }
         
-        if (epd_.size() > static_cast<std::size_t>(start_ + rounds_ - 1)) {
-            epd_.erase(epd_.begin() + (start_ + rounds_ - 1), epd_.end());
+        if (epd_.size() > static_cast<std::size_t>(start_ + rounds_ - 1 + matchcount_ / games_)) {
+            epd_.erase(epd_.begin() + (start_ + rounds_ - 1 + matchcount_ / games_), epd_.end());
             epd_.shrink_to_fit();
         }
 

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -27,7 +27,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         pgn = pgn::PgnReader(file, plies_).getOpenings();
         
         if (pgn.size() > games_ * rounds_) {
-            epd.erase(pgn.begin() + games_ * rounds_, pgn.end());
+            pgn.erase(pgn.begin() + games_ * rounds_, pgn.end());
         }
         
         book_ = pgn;

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -21,9 +21,12 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
         return;
     }
 
+    std::size_t total_games = static_cast<std::size_t>(games_ * rounds_)
+    
     if (type == FormatType::PGN) {
         pgn_ = pgn::PgnReader(file, plies_).getOpenings();
-        
+
+        // Fisher-Yates / Knuth shuffle
         if (order_ == OrderType::RANDOM) {
              for (std::size_t i = 0; i + 2 <= pgn_.size(); i++) {
                  auto rand     = util::random::mersenne_rand();
@@ -31,9 +34,9 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
                  std::swap(vec[i], vec[j]);
              }
         }
-        
-        if (pgn_.size() > games_ * rounds_) {
-            pgn_.erase(pgn_.begin() + games_ * rounds_, pgn_.end());
+
+        if (pgn_.size() > total_games) {
+            pgn_.erase(pgn_.begin() + total_games, pgn_.end());
         }
 
         if (pgn_.empty()) {
@@ -51,6 +54,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
 
         openingFile.close();
 
+        // Fisher-Yates / Knuth shuffle
         if (order_ == OrderType::RANDOM) {
              for (std::size_t i = 0; i + 2 <= epd_.size(); i++) {
                  auto rand     = util::random::mersenne_rand();
@@ -59,8 +63,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              }
         }
         
-        if (epd_.size() > games_ * rounds_) {
-            epd_.erase(epd_.begin() + games_ * rounds_, epd_.end());
+        if (epd_.size() > total_games) {
+            epd_.erase(epd_.begin() + total_games, epd_.end());
         }
 
         if (epd_.empty()) {

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -33,8 +33,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              }
         }
 
-        if (pgn_.size() > static_cast<std::size_t>(rounds_)) {
-            pgn_.erase(pgn_.begin() + rounds_, pgn_.end());
+        if (pgn_.size() > static_cast<std::size_t>(start_ + rounds_ - 1)) {
+            pgn_.erase(pgn_.begin() + (start_ + rounds_ - 1), pgn_.end());
             pgn_.shrink_to_fit();
         }
 
@@ -62,8 +62,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              }
         }
         
-        if (epd_.size() > static_cast<std::size_t>(rounds_)) {
-            epd_.erase(epd_.begin() + rounds_, epd_.end());
+        if (epd_.size() > static_cast<std::size_t>(start_ + rounds_ - 1)) {
+            epd_.erase(epd_.begin() + (start_ + rounds_ - 1), epd_.end());
             epd_.shrink_to_fit();
         }
 

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -20,8 +20,6 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     if (file.empty()) {
         return;
     }
-
-    std::size_t total_games = static_cast<std::size_t>(games_ * rounds_);
     
     if (type == FormatType::PGN) {
         pgn_ = pgn::PgnReader(file, plies_).getOpenings();
@@ -35,8 +33,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              }
         }
 
-        if (pgn_.size() > total_games) {
-            pgn_.erase(pgn_.begin() + total_games, pgn_.end());
+        if (pgn_.size() > static_cast<std::size_t>(rounds_)) {
+            pgn_.erase(pgn_.begin() + rounds_, pgn_.end());
             pgn_.shrink_to_fit();
         }
 
@@ -64,8 +62,8 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
              }
         }
         
-        if (epd_.size() > total_games) {
-            epd_.erase(epd_.begin() + total_games, epd_.end());
+        if (epd_.size() > rounds_) {
+            epd_.erase(epd_.begin() + static_cast<std::size_t>(rounds_), epd_.end());
             epd_.shrink_to_fit();
         }
 

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -24,7 +24,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     if (type == FormatType::PGN) {
         pgn_ = pgn::PgnReader(file, plies_).getOpenings();
         
-        if (order_ == OrderType::RANDOM) shuffle(type);
+        if (order_ == OrderType::RANDOM) shuffle(epd);
         
         if (pgn.size() > games_ * rounds_) {
             pgn_.erase(pgn_.begin() + games_ * rounds_, pgn_.end());
@@ -45,7 +45,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
 
         openingFile.close();
 
-        if (order_ == OrderType::RANDOM) shuffle(type);
+        if (order_ == OrderType::RANDOM) shuffle(pgn);
         
         if (epd_.size() > games_ * rounds_) {
             epd_.erase(epd_.begin() + games_ * rounds_, epd_.end());

--- a/src/book/opening_book.hpp
+++ b/src/book/opening_book.hpp
@@ -42,6 +42,7 @@ class OpeningBook {
     std::size_t start_      = 0;
     std::size_t matchcount_ = 0;
     int games_;
+    int rounds_;
     int plies_;
     OrderType order_;
     std::variant<epd_book, pgn_book> book_;

--- a/src/book/opening_book.hpp
+++ b/src/book/opening_book.hpp
@@ -45,7 +45,8 @@ class OpeningBook {
     int rounds_;
     int plies_;
     OrderType order_;
-    std::variant<epd_book, pgn_book> book_;
+    std::vector<std::string> epd_;
+    std::vector<pgn::Opening> pgn_;
 };
 
 }  // namespace fast_chess::book

--- a/src/book/opening_book.hpp
+++ b/src/book/opening_book.hpp
@@ -16,15 +16,6 @@ class OpeningBook {
     OpeningBook() = default;
     explicit OpeningBook(const options::Tournament& tournament);
 
-    // Fisher-Yates / Knuth shuffle
-    void shuffle(auto& vec) {
-         for (std::size_t i = 0; i + 2 <= vec.size(); i++) {
-             auto rand     = util::random::mersenne_rand();
-             std::size_t j = i + (rand % (vec.size() - i));
-             std::swap(vec[i], vec[j]);
-         }
-    }
-
     [[nodiscard]] pgn::Opening fetch() noexcept;
 
     void setInternalOffset(std::size_t offset) noexcept { matchcount_ = offset; }

--- a/src/book/opening_book.hpp
+++ b/src/book/opening_book.hpp
@@ -17,19 +17,12 @@ class OpeningBook {
     explicit OpeningBook(const options::Tournament& tournament);
 
     // Fisher-Yates / Knuth shuffle
-    void shuffle(FormatType type) {
-        const auto shuffle = [](auto& vec) {
-            for (std::size_t i = 0; i + 2 <= vec.size(); i++) {
-                auto rand     = util::random::mersenne_rand();
-                std::size_t j = i + (rand % (vec.size() - i));
-                std::swap(vec[i], vec[j]);
-            }
-        };
-
-        if (type == FormatType::EPD)
-           std::visit(shuffle, epd_);
-        else if (type == FormatType::PGN)
-           std::visit(shuffle, pgn_);
+    void shuffle(auto& vec) {
+         for (std::size_t i = 0; i + 2 <= vec.size(); i++) {
+             auto rand     = util::random::mersenne_rand();
+             std::size_t j = i + (rand % (vec.size() - i));
+             std::swap(vec[i], vec[j]);
+         }
     }
 
     [[nodiscard]] pgn::Opening fetch() noexcept;

--- a/src/book/opening_book.hpp
+++ b/src/book/opening_book.hpp
@@ -17,7 +17,7 @@ class OpeningBook {
     explicit OpeningBook(const options::Tournament& tournament);
 
     // Fisher-Yates / Knuth shuffle
-    void shuffle() {
+    void shuffle(FormatType type) {
         const auto shuffle = [](auto& vec) {
             for (std::size_t i = 0; i + 2 <= vec.size(); i++) {
                 auto rand     = util::random::mersenne_rand();
@@ -26,7 +26,10 @@ class OpeningBook {
             }
         };
 
-        std::visit(shuffle, book_);
+        if (type == FormatType::EPD)
+           std::visit(shuffle, epd_);
+        else if (type == FormatType::PGN)
+           std::visit(shuffle, pgn_);
     }
 
     [[nodiscard]] pgn::Opening fetch() noexcept;
@@ -35,9 +38,6 @@ class OpeningBook {
 
    private:
     void setup(const std::string& file, FormatType type);
-
-    using epd_book = std::vector<std::string>;
-    using pgn_book = std::vector<pgn::Opening>;
 
     std::size_t start_      = 0;
     std::size_t matchcount_ = 0;


### PR DESCRIPTION
reduce memory usage when using books https://github.com/Disservin/fast-chess/issues/439

before:
![Screenshot 2024-06-11 025013](https://github.com/Disservin/fast-chess/assets/155860115/a651189b-f7f8-4102-8c05-f906d817382f)

after:
![Screenshot 2024-06-11 055940](https://github.com/Disservin/fast-chess/assets/155860115/e9b0ffd0-c608-4325-afe6-2991c20db994)


idk how cutechess does it, but they somehow manage to keep memory usage fixed at 80MB even with 1 million games, do they somehow not load the book into memory?
