### PR TITLE
refactor: better termination message when engine outputs no best moves

### DIFF
--- a/src/matchmaking/match/match.cpp
+++ b/src/matchmaking/match/match.cpp
@@ -207,14 +207,14 @@ bool Match::playMove(Player& us, Player& opponent) {
     if (!legal) {
         setLose(us, opponent);
 
-        if (best_move != "aaaa") {
+        if (best_move == "aaaa") {
+            data_.termination = MatchTermination::NO_BESTMOVE;
+            data_.reason      = name + Match::NO_BESTMOVE_MSG;
+        } else {
             data_.termination = MatchTermination::ILLEGAL_MOVE;
             data_.reason      = name + Match::ILLEGAL_MSG;
     
             Logger::log<Logger::Level::WARN>("Warning; Illegal move", best_move, "played by", name);
-        } else {
-            data_.termination = MatchTermination::NO_BESTMOVE;
-            data_.reason      = name + Match::NO_BESTMOVE_MSG;
         }
 
         return false;

--- a/src/matchmaking/match/match.cpp
+++ b/src/matchmaking/match/match.cpp
@@ -207,10 +207,15 @@ bool Match::playMove(Player& us, Player& opponent) {
     if (!legal) {
         setLose(us, opponent);
 
-        data_.termination = MatchTermination::ILLEGAL_MOVE;
-        data_.reason      = name + Match::ILLEGAL_MSG;
-
-        Logger::log<Logger::Level::WARN>("Warning; Illegal move", best_move, "played by", name);
+        if (best_move != "aaaa") {
+            data_.termination = MatchTermination::ILLEGAL_MOVE;
+            data_.reason      = name + Match::ILLEGAL_MSG;
+    
+            Logger::log<Logger::Level::WARN>("Warning; Illegal move", best_move, "played by", name);
+        } else {
+            data_.termination = MatchTermination::NO_BESTMOVE;
+            data_.reason      = name + Match::NO_BESTMOVE_MSG;
+        }
 
         return false;
     }

--- a/src/matchmaking/match/match.hpp
+++ b/src/matchmaking/match/match.hpp
@@ -159,7 +159,7 @@ class Match {
     inline static constexpr char INSUFFICIENT_MSG[]     = "Draw by insufficient material";
     inline static constexpr char REPETITION_MSG[]       = "Draw by 3-fold repetition";
     inline static constexpr char ILLEGAL_MSG[]          = " made an illegal move";
-    inline static constexpr char NO_BESTMOVE_MSG[]      = " does not send a bestmove";
+    inline static constexpr char NO_BESTMOVE_MSG[]      = " did not send a bestmove";
     inline static constexpr char ADJUDICATION_WIN_MSG[] = " wins by adjudication";
     inline static constexpr char ADJUDICATION_MSG[]     = "Draw by adjudication";
     inline static constexpr char FIFTY_MSG[]            = "Draw by 50-move rule";

--- a/src/matchmaking/match/match.hpp
+++ b/src/matchmaking/match/match.hpp
@@ -159,6 +159,7 @@ class Match {
     inline static constexpr char INSUFFICIENT_MSG[]     = "Draw by insufficient material";
     inline static constexpr char REPETITION_MSG[]       = "Draw by 3-fold repetition";
     inline static constexpr char ILLEGAL_MSG[]          = " made an illegal move";
+    inline static constexpr char NO_BESTMOVE_MSG[]      = " does not send a bestmove";
     inline static constexpr char ADJUDICATION_WIN_MSG[] = " wins by adjudication";
     inline static constexpr char ADJUDICATION_MSG[]     = "Draw by adjudication";
     inline static constexpr char FIFTY_MSG[]            = "Draw by 50-move rule";

--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -182,7 +182,7 @@ std::string PgnBuilder::convertMatchTermination(const MatchTermination &res) noe
         case MatchTermination::ILLEGAL_MOVE:
             return "illegal move";
         case MatchTermination::NO_BESTMOVE:
-            return "no bestmove sent";
+            return "no bestmove received";
         case MatchTermination::INTERRUPT:
             return "unterminated";
         default:

--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -181,6 +181,8 @@ std::string PgnBuilder::convertMatchTermination(const MatchTermination &res) noe
             return "time forfeit";
         case MatchTermination::ILLEGAL_MOVE:
             return "illegal move";
+        case MatchTermination::NO_BESTMOVE:
+            return "no bestmove sent";
         case MatchTermination::INTERRUPT:
             return "unterminated";
         default:

--- a/src/pgn/pgn_builder.cpp
+++ b/src/pgn/pgn_builder.cpp
@@ -181,8 +181,10 @@ std::string PgnBuilder::convertMatchTermination(const MatchTermination &res) noe
             return "time forfeit";
         case MatchTermination::ILLEGAL_MOVE:
             return "illegal move";
+        case MatchTermination::DISCONNECT:
+            return "abandoned";
         case MatchTermination::NO_BESTMOVE:
-            return "no bestmove received";
+            return "abandoned";
         case MatchTermination::INTERRUPT:
             return "unterminated";
         default:

--- a/src/types/match_data.hpp
+++ b/src/types/match_data.hpp
@@ -44,6 +44,7 @@ enum class MatchTermination {
     TIMEOUT,
     DISCONNECT,
     ILLEGAL_MOVE,
+    NO_BESTMOVE,
     INTERRUPT,
     None,
 };


### PR DESCRIPTION
when no bestmove is sent, characterized by bm "aaaa" https://github.com/Disservin/fast-chess/blob/7f414cc52bd612d0db0d5c65171a389a9e8a6813/src/engine/uci_engine.cpp#L145 then it has its own dedicated no bestmove termination message