### PR TITLE
fix logger thread id formatting

### DIFF
--- a/src/util/logger/logger.cpp
+++ b/src/util/logger/logger.cpp
@@ -28,7 +28,7 @@ void Logger::writeToEngine(const std::string &msg, const std::string &time, cons
 
     ss                                                                 //
         << "[" << time << "] "                                         //
-        << " <" << std::setw(3) << std::this_thread::get_id() << "> "  //
+        << " <" << std::this_thread::get_id() << "> "  //
         << name                                                        //
         << " <--- " << msg                                             //
         << std::endl;
@@ -45,7 +45,7 @@ void Logger::readFromEngine(const std::string &msg, const std::string &time, con
 
     std::stringstream ss;
     ss                                                                                        //
-        << "[" << time << "] " << " <" << std::setw(3) << std::this_thread::get_id() << "> "  //
+        << "[" << time << "] " << " <" << std::this_thread::get_id() << "> "  //
         << name                                                                               //
         << (err ? " 1 " : " 2 ")                                                              //
         << "---> " << msg                                                                     //

--- a/src/util/logger/logger.hpp
+++ b/src/util/logger/logger.hpp
@@ -46,7 +46,7 @@ class Logger {
 
         if constexpr (thread) {
             file_ss << "[" << util::time::datetime_precise() << "] "               //
-                    << " <" << std::setw(3) << std::this_thread::get_id() << "> "  //
+                    << " <" << std::this_thread::get_id() << "> "  //
                     << "fastchess"                                                 //
                     << " --- "                                                     //
                     << ss.str();


### PR DESCRIPTION
fix this:
![Screenshot 2024-06-18 060804](https://github.com/Disservin/fast-chess/assets/155860115/019d0486-3eb6-4a13-9882-244e3d273956)
