### PR TITLE
refactor: better way of shrinking the book vector

### DIFF
--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -57,7 +57,16 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
 
     rotate(offset_);
     truncate(rounds_);
-    shrink();
+
+    if (type == FormatType::EPD) {
+        std::vector<std::string> tmp(std::get<epd_book>(book_).begin(), std::get<epd_book>(book_).end());
+        std::get<epd_book>(book_).swap(tmp);
+        std::get<epd_book>(book_).shrink_to_fit();
+    } else {
+        std::vector<pgn::Opening> tmp(std::get<pgn_book>(book_).begin(), std::get<pgn_book>(book_).end());
+        std::get<pgn_book>(book_).swap(tmp);
+        std::get<pgn_book>(book_).shrink_to_fit();
+    }
 }
 
 [[nodiscard]] std::optional<std::size_t> OpeningBook::fetchId() noexcept {

--- a/src/book/opening_book.cpp
+++ b/src/book/opening_book.cpp
@@ -58,6 +58,7 @@ void OpeningBook::setup(const std::string& file, FormatType type) {
     rotate(offset_);
     truncate(rounds_);
 
+    // force deallocation of memory
     if (type == FormatType::EPD) {
         std::vector<std::string> tmp(std::get<epd_book>(book_).begin(), std::get<epd_book>(book_).end());
         std::get<epd_book>(book_).swap(tmp);

--- a/src/book/opening_book.hpp
+++ b/src/book/opening_book.hpp
@@ -50,13 +50,6 @@ class OpeningBook {
         std::visit(truncate, book_);
     }
 
-    // Shrink book vector
-    void shrink() {
-        const auto shrink = [](auto& vec) { vec.shrink_to_fit(); };
-
-        std::visit(shrink, book_);
-    }
-
     [[nodiscard]] std::optional<std::size_t> fetchId() noexcept;
 
     pgn::Opening operator[](std::optional<std::size_t> idx) const noexcept {

--- a/src/book/opening_book.hpp
+++ b/src/book/opening_book.hpp
@@ -50,14 +50,15 @@ class OpeningBook {
         std::visit(truncate, book_);
     }
 
-   void shrink() {
-       std::visit([&](auto& book) {
-           using BookType = std::decay_t<decltype(book)>;
-           std::vector<typename BookType::value_type> tmp(book.begin(), book.end());
-           book.swap(tmp);
-           book.shrink_to_fit();
-       }, book_);
-   }
+    // Shrink book vector
+    void shrink() {
+        std::visit([&](auto& book) {
+            using BookType = std::decay_t<decltype(book)>;
+            std::vector<typename BookType::value_type> tmp(book.begin(), book.end());
+            book.swap(tmp);
+            book.shrink_to_fit();
+        }, book_);
+    }
 
     [[nodiscard]] std::optional<std::size_t> fetchId() noexcept;
 


### PR DESCRIPTION
the current way of shrinking the vector is by relying on the shrink_to_fit() function to get rid of excess memory usage. this is not ideal since shrink_to_fit() is implementation defined and a non-binding request, so its completely up to the memory allocator how much memory it frees up. with this patch the shrinking is done using the vector swap trick where the vector is swapped with a temporary copy that immediately goes out of scope. this 100% ensures complete memory reduction.

here is a comparison of the memory usage in a match of 1000 rounds using UHO lichess book with shrink_to_fit() method and vector swap method:

shrink_to_fit():
![Screenshot 2024-06-19 155614](https://github.com/Disservin/fast-chess/assets/155860115/71227f93-d2e5-4ef2-b86b-5009f83d0763)

vector swap trick:
![Screenshot 2024-06-19 155353](https://github.com/Disservin/fast-chess/assets/155860115/5ae170e3-d6a9-4113-8994-d21d640b5f87)

as can be seen, the new method is much more effective and reliable.
