### PR TITLE
feat: reimplement recover option

### DIFF
--- a/src/matchmaking/match/match.cpp
+++ b/src/matchmaking/match/match.cpp
@@ -155,6 +155,8 @@ bool Match::playMove(Player& us, Player& opponent) {
     if (!us.engine.isResponsive()) {
         setLose(us, opponent);
 
+        crash_or_disconnect_ = true;
+
         data_.termination = MatchTermination::DISCONNECT;
         data_.reason      = name + Match::DISCONNECT_MSG;
 
@@ -171,6 +173,8 @@ bool Match::playMove(Player& us, Player& opponent) {
     // wait for readyok
     if (!us.engine.isResponsive()) {
         setLose(us, opponent);
+
+        crash_or_disconnect_ = true;
 
         data_.termination = MatchTermination::DISCONNECT;
         data_.reason      = name + Match::DISCONNECT_MSG;
@@ -190,6 +194,8 @@ bool Match::playMove(Player& us, Player& opponent) {
 
     if (status == engine::process::Status::ERR || !us.engine.isResponsive()) {
         setLose(us, opponent);
+
+        crash_or_disconnect_ = true;
 
         data_.termination = MatchTermination::DISCONNECT;
         data_.reason      = name + Match::DISCONNECT_MSG;

--- a/src/matchmaking/match/match.hpp
+++ b/src/matchmaking/match/match.hpp
@@ -114,6 +114,8 @@ class Match {
     // returns the match data, only valid after the match has finished
     [[nodiscard]] const MatchData& get() const { return data_; }
 
+    [[nodiscard]] bool isCrashOrDisconnect() const noexcept { return crash_or_disconnect_; }
+
    private:
     static bool isUciMove(const std::string& move) noexcept;
     void verifyPvLines(const Player& us);
@@ -152,6 +154,8 @@ class Match {
     // start position, required for the uci position command
     // is either startpos or the fen of the opening
     std::string start_position_;
+
+    bool crash_or_disconnect_ = false;
 
     inline static constexpr char INSUFFICIENT_MSG[]     = "Draw by insufficient material";
     inline static constexpr char REPETITION_MSG[]       = "Draw by 3-fold repetition";

--- a/src/matchmaking/tournament/base/tournament.cpp
+++ b/src/matchmaking/tournament/base/tournament.cpp
@@ -106,8 +106,6 @@ void BaseTournament::playGame(const std::pair<EngineConfiguration, EngineConfigu
     }
 
     finish({match_data}, match_data.reason);
-
-    if (atomic::stop) return;
 }
 
 int BaseTournament::getMaxAffinity(const std::vector<EngineConfiguration> &configs) const noexcept {

--- a/src/matchmaking/tournament/base/tournament.cpp
+++ b/src/matchmaking/tournament/base/tournament.cpp
@@ -103,9 +103,9 @@ void BaseTournament::playGame(const std::pair<EngineConfiguration, EngineConfigu
             file_writer_pgn->write(pgn::PgnBuilder(match_data, tournament_options_, game_id + 1).get());
         if (!tournament_options_.epd.file.empty())
             file_writer_epd->write(epd::EpdBuilder(match_data, tournament_options_).get());
-    }
 
-    finish({match_data}, match_data.reason);
+        finish({match_data}, match_data.reason);
+    }
 }
 
 int BaseTournament::getMaxAffinity(const std::vector<EngineConfiguration> &configs) const noexcept {


### PR DESCRIPTION
when passed `-recover` the engine that disconnected/crashed  will lose the game and the tournament continues with the next match and unresponsive engines are restarted