### PR TITLE
fix parseRandomSeed

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -515,7 +515,7 @@ void parseRandomSeed(const std::vector<std::string> &, ArgumentData &argument_da
     argument_data.tournament_options.randomseed = true;
 
     std::random_device rd;
-    std::mt19937_64 gen(rd());
+    std::mt19937_64 gen((static_cast<uint64_t>(rd()) << 32) | rd());
     std::uniform_int_distribution<uint64_t> dist(0, std::numeric_limits<uint64_t>::max());
     argument_data.tournament_options.seed = dist(gen);
 }


### PR DESCRIPTION
this is how its used with the std::mt19937_64:

![Screenshot 2024-06-21 002905](https://github.com/Disservin/fast-chess/assets/155860115/b2390ffd-e350-4c32-8ca3-137f94ff1e12)
