### PR TITLE
feat: display tc, hash, threads, and book in fastchess output

### DIFF
--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -124,14 +124,11 @@ void UciEngine::quit() {
 
 void UciEngine::sendSetoption(const std::string &name, const std::string &value) {
     Logger::trace<true>("Sending setoption to engine {} {} {}", config_.name, name, value);
-<<<<<<< HEAD
     if (!writeEngine(fmt::format("setoption name {} value {}", name, value))) {
         Logger::trace<true>("Failed to send setoption to engine {} {} {}", config_.name, name, value);
+    } else {
+        uci_options_[name] = value;
     }
-=======
-    writeEngine("setoption name " + name + " value " + value);
-    uci_options_[name] = value;
->>>>>>> feat: add logic to get set options from engine
 }
 
 void UciEngine::start() {

--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <chess.hpp>
@@ -79,9 +80,13 @@ class UciEngine : protected process::Process {
 #endif
     );
 
+    [[nodiscard]] std::optional<std::string> getOption(const std::string &name) const;
+
    private:
     void loadConfig(const EngineConfiguration &config);
     void sendSetoption(const std::string &name, const std::string &value);
+
+    std::unordered_map<std::string, std::string> uci_options_;
 
     EngineConfiguration config_;
 

--- a/app/src/matchmaking/output/output.hpp
+++ b/app/src/matchmaking/output/output.hpp
@@ -21,7 +21,10 @@ class IOutput {
 
     // Interval output. Get's displayed every n `ratinginterval`.
     virtual void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
-                               const std::string& second) {
+                               const std::string& second, 
+                               std::vector<std::pair<std::string, std::string>>& options1, 
+                               std::vector<std::pair<std::string, std::string>>& options2,
+                               Limit& limit1, Limit& limit2, const std::string& book) {
         std::cout << "--------------------------------------------------\n";
         printElo(stats, first, second, options1, options2, limit1, limit2, book);
         printSprt(sprt, stats);

--- a/app/src/matchmaking/output/output.hpp
+++ b/app/src/matchmaking/output/output.hpp
@@ -22,9 +22,9 @@ class IOutput {
     // Interval output. Get's displayed every n `ratinginterval`.
     virtual void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
                                const std::string& second, 
-                               std::vector<std::pair<std::string, std::string>>& options1, 
-                               std::vector<std::pair<std::string, std::string>>& options2,
-                               Limit& limit1, Limit& limit2, const std::string& book) {
+                               const std::vector<std::pair<std::string, std::string>>& options1, 
+                               const std::vector<std::pair<std::string, std::string>>& options2,
+                               const Limit& limit1, const Limit& limit2, const std::string& book) {
         std::cout << "--------------------------------------------------\n";
         printElo(stats, first, second, options1, options2, limit1, limit2, book);
         printSprt(sprt, stats);

--- a/app/src/matchmaking/output/output.hpp
+++ b/app/src/matchmaking/output/output.hpp
@@ -36,9 +36,9 @@ class IOutput {
 
     // Print current H2H elo stats.
     virtual void printElo(const Stats& stats, const std::string& first, const std::string& second,
-                          std::vector<std::pair<std::string, std::string>>& options1, 
-                          std::vector<std::pair<std::string, std::string>>& options2,
-                          Limit& limit1, Limit& limit2, const std::string& book) = 0;
+                          const std::vector<std::pair<std::string, std::string>>& options1, 
+                          const std::vector<std::pair<std::string, std::string>>& options2,
+                          const Limit& limit1, const Limit& limit2, const std::string& book) = 0;
 
     // Print current SPRT stats.
     virtual void printSprt(const SPRT& sprt, const Stats& stats) = 0;

--- a/app/src/matchmaking/output/output.hpp
+++ b/app/src/matchmaking/output/output.hpp
@@ -32,7 +32,10 @@ class IOutput {
     virtual void printResult(const Stats& stats, const std::string& first, const std::string& second) = 0;
 
     // Print current H2H elo stats.
-    virtual void printElo(const Stats& stats, const std::string& first, const std::string& second) = 0;
+    virtual void printElo(const Stats& stats, const std::string& first, const std::string& second,
+                          std::vector<std::pair<std::string, std::string>>& options1, 
+                          std::vector<std::pair<std::string, std::string>>& options2,
+                          Limit& limit1, Limit& limit2, const std::string& book) = 0;
 
     // Print current SPRT stats.
     virtual void printSprt(const SPRT& sprt, const Stats& stats) = 0;

--- a/app/src/matchmaking/output/output.hpp
+++ b/app/src/matchmaking/output/output.hpp
@@ -23,7 +23,7 @@ class IOutput {
     virtual void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
                                const std::string& second) {
         std::cout << "--------------------------------------------------\n";
-        printElo(stats, first, second);
+        printElo(stats, first, second, options1, options2, limit1, limit2, book);
         printSprt(sprt, stats);
         std::cout << "--------------------------------------------------\n";
     };

--- a/app/src/matchmaking/output/output.hpp
+++ b/app/src/matchmaking/output/output.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 
 #include <cli/cli.hpp>
 #include <matchmaking/sprt/sprt.hpp>
@@ -13,6 +14,10 @@ namespace fast_chess {
 
 using pair_config = std::pair<EngineConfiguration, EngineConfiguration>;
 
+namespace engine {
+class UciEngine;
+}
+
 // Interface for outputting current tournament state to the user.
 class IOutput {
    public:
@@ -21,12 +26,11 @@ class IOutput {
 
     // Interval output. Get's displayed every n `ratinginterval`.
     virtual void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
-                               const std::string& second, 
-                               const std::vector<std::pair<std::string, std::string>>& options1, 
-                               const std::vector<std::pair<std::string, std::string>>& options2,
-                               const Limit& limit1, const Limit& limit2, const std::string& book) {
+                               const std::string& second,
+                               const std::pair<const engine::UciEngine&, const engine::UciEngine&>& engines,
+                               const std::string& book) {
         std::cout << "--------------------------------------------------\n";
-        printElo(stats, first, second, options1, options2, limit1, limit2, book);
+        printElo(stats, first, second, engines, book);
         printSprt(sprt, stats);
         std::cout << "--------------------------------------------------\n";
     };
@@ -36,9 +40,8 @@ class IOutput {
 
     // Print current H2H elo stats.
     virtual void printElo(const Stats& stats, const std::string& first, const std::string& second,
-                          const std::vector<std::pair<std::string, std::string>>& options1, 
-                          const std::vector<std::pair<std::string, std::string>>& options2,
-                          const Limit& limit1, const Limit& limit2, const std::string& book) = 0;
+                          const std::pair<const engine::UciEngine&, const engine::UciEngine&>& engines,
+                          const std::string& book) = 0;
 
     // Print current SPRT stats.
     virtual void printSprt(const SPRT& sprt, const Stats& stats) = 0;

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -13,7 +13,7 @@ class Cutechess : public IOutput {
                        std::vector<std::pair<std::string, std::string>>& options1, 
                        std::vector<std::pair<std::string, std::string>>& options2,
                        Limit& limit1, Limit& limit2, const std::string& book) override {
-        printElo(stats, first, second, options1, options2, limit1, limit2);
+        printElo(stats, first, second, options1, options2, limit1, limit2, book);
         printSprt(sprt, stats);
     };
 

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -8,12 +8,10 @@ namespace fast_chess {
 
 class Cutechess : public IOutput {
    public:
-    void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
-                       const std::string& second, 
-                       const std::vector<std::pair<std::string, std::string>>& options1, 
-                       const std::vector<std::pair<std::string, std::string>>& options2,
-                       const Limit& limit1, const Limit& limit2, const std::string& book) override {
-        printElo(stats, first, second, options1, options2, limit1, limit2, book);
+    void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first, const std::string& second,
+                       const std::pair<const engine::UciEngine&, const engine::UciEngine&>& engines,
+                       const std::string& book) override {
+        printElo(stats, first, second, engines, book);
         printSprt(sprt, stats);
     };
 
@@ -41,9 +39,7 @@ class Cutechess : public IOutput {
     }
 
     void printElo(const Stats& stats, const std::string&, const std::string&,
-                  const std::vector<std::pair<std::string, std::string>>&, 
-                  const std::vector<std::pair<std::string, std::string>>&,
-                  const Limit&, const Limit&, const std::string&) override {
+                  const std::pair<const engine::UciEngine&, const engine::UciEngine&>&, const std::string&) override {
         const elo::EloWDL elo(stats);
 
         std::stringstream ss;

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -37,7 +37,10 @@ class Cutechess : public IOutput {
         std::cout << ss.str() << std::flush;
     }
 
-    void printElo(const Stats& stats, const std::string&, const std::string&) override {
+    void printElo(const Stats& stats, const std::string&, const std::string&,
+                  std::vector<std::pair<std::string, std::string>>&, 
+                  std::vector<std::pair<std::string, std::string>>&,
+                  Limit&, Limit&, const std::string&) override {
         const elo::EloWDL elo(stats);
 
         std::stringstream ss;

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -10,9 +10,9 @@ class Cutechess : public IOutput {
    public:
     void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
                        const std::string& second, 
-                       std::vector<std::pair<std::string, std::string>>& options1, 
-                       std::vector<std::pair<std::string, std::string>>& options2,
-                       Limit& limit1, Limit& limit2, const std::string& book) override {
+                       const std::vector<std::pair<std::string, std::string>>& options1, 
+                       const std::vector<std::pair<std::string, std::string>>& options2,
+                       const Limit& limit1, const Limit& limit2, const std::string& book) override {
         printElo(stats, first, second, options1, options2, limit1, limit2, book);
         printSprt(sprt, stats);
     };
@@ -41,9 +41,9 @@ class Cutechess : public IOutput {
     }
 
     void printElo(const Stats& stats, const std::string&, const std::string&,
-                  std::vector<std::pair<std::string, std::string>>&, 
-                  std::vector<std::pair<std::string, std::string>>&,
-                  Limit&, Limit&, const std::string&) override {
+                  const std::vector<std::pair<std::string, std::string>>&, 
+                  const std::vector<std::pair<std::string, std::string>>&,
+                  const Limit&, const Limit&, const std::string&) override {
         const elo::EloWDL elo(stats);
 
         std::stringstream ss;

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -9,8 +9,11 @@ namespace fast_chess {
 class Cutechess : public IOutput {
    public:
     void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
-                       const std::string& second) override {
-        printElo(stats, first, second);
+                       const std::string& second, 
+                       std::vector<std::pair<std::string, std::string>>& options1, 
+                       std::vector<std::pair<std::string, std::string>>& options2,
+                       Limit& limit1, Limit& limit2, const std::string& book) override {
+        printElo(stats, first, second, options1, options2, limit1, limit2);
         printSprt(sprt, stats);
     };
 

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -46,20 +46,46 @@ class Fastchess : public IOutput {
 
         if (inc1 != 0)
             ss << "+" << inc1 / 1000.0;
+       
+        if (tc1 != tc2 && movestogo1 != movestogo2 && inc1 != inc2) {
+             ss << " - ";
+           
+            if (movestogo2 != 0)
+                ss << movestogo2 << "/";
+   
+            ss << tc2 / 1000.0;
+   
+            if (inc2 != 0)
+                ss << "+" << inc2 / 1000.0;
+        }
 
         ss << ", "
            << threads1
-           << "t - "
-           << threads2
-           << "t, "
-           << hash1
-           << "MB - "
-           << hash2
-           << "MB, "
-           << book
-           << "):\n";
+           << "t";
+       
+        if (threads1 != threads2) {
+            ss << " - "
+               << threads2
+               << "t";
+        }
 
-        ss << "Elo: "        //
+        ss << ", "
+           << hash1
+           << "MB";
+
+        if (hash1 != hash2) {
+            ss << " - "
+               << hash2
+               << "MB";
+        }
+           
+        if (!book.empty()) {
+            ss << ", "
+               << book;
+        }
+       
+        ss << "):\n"
+           << "Elo: "        //
            << elo->getElo()  //
            << ", nElo: "     //
            << elo->nElo()    //

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -28,7 +28,14 @@ class Fastchess : public IOutput {
                   std::vector<std::pair<std::string, std::string>>& options2,
                   Limit& limit1, Limit& limit2) override {
         std::unique_ptr<elo::EloBase> elo;
-        int movestogo1 = limit1.movestogo
+        int movestogo1 = limit1.tc.moves;
+        int movestogo2 = limit2.tc.moves;
+        int fixed_time1 = limit1.tc.fixed_time;
+        int fixed_time2 = limit2.tc.fixed_time
+        int tc1 = limit1.tc.time;
+        int tc2 = limit2.tc.time;
+        int nodes1 = limit1.nodes;
+        int nodes2 = limit2.nodes;
 
         if (report_penta_) {
             elo = std::make_unique<elo::EloPentanomial>(stats);

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -41,10 +41,10 @@ class Fastchess : public IOutput {
         int nodes2 = limit2.nodes;
         int plies1 = limit1.plies;
         int plies2 = limit2.plies;
-        std::string threads1 = "{}"
-        std::string threads2 = "{}"
-        std::string hash1 = "{}"
-        std::string hash2 = "{}"
+        std::string threads1 = "{}";
+        std::string threads2 = "{}";
+        std::string hash1 = "{}";
+        std::string hash2 = "{}";
         auto hash1it = std::find_if(options1.begin(), options1.end(),
                            [](const std::pair<std::string, std::string>& element) {
                                return element.first == "Hash";

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -26,7 +26,7 @@ class Fastchess : public IOutput {
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
                   std::vector<std::pair<std::string, std::string>>& options1, 
                   std::vector<std::pair<std::string, std::string>>& options2,
-                  Limit& limit1, Limit& limit2) override {
+                  Limit& limit1, Limit& limit2, const std::string& book) override {
         std::unique_ptr<elo::EloBase> elo;
         int movestogo1 = limit1.tc.moves;
         int movestogo2 = limit2.tc.moves;
@@ -38,6 +38,30 @@ class Fastchess : public IOutput {
         int nodes2 = limit2.nodes;
         int plies1 = limit1.plies;
         int plies2 = limit2.plies;
+        std::string threads1 = "{}"
+        std::string threads2 = "{}"
+        std::string hash1 = "{}"
+        std::string hash2 = "{}"
+        auto hash1it = std::find_if(options1.begin(), options1.end(),
+                           [](const std::pair<std::string, std::string>& element) {
+                               return element.first == "Hash";
+                           });
+        auto hash2it = std::find_if(options2.begin(), options2.end(),
+                           [](const std::pair<std::string, std::string>& element) {
+                               return element.first == "Hash";
+                           });
+        auto threads1it = std::find_if(options1.begin(), options1.end(),
+                           [](const std::pair<std::string, std::string>& element) {
+                               return element.first == "Threads";
+                           });
+        auto threads2it = std::find_if(options2.begin(), options2.end(),
+                           [](const std::pair<std::string, std::string>& element) {
+                               return element.first == "Threads";
+                           });
+        if (hash1it != options1.end()) hash1 = hash1it->second;
+        if (hash2it != options2.end()) hash2 = hash2it->second;
+        if (threads1it != options1.end()) threads1 = threads1it->second;
+        if (threads2it != options2.end()) threads1 = threads2it->second;
 
         if (report_penta_) {
             elo = std::make_unique<elo::EloPentanomial>(stats);

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -65,7 +65,12 @@ class Fastchess : public IOutput {
         const auto pairsRatio =
             static_cast<double>(stats.penta_WW + stats.penta_WD) / (stats.penta_LD + stats.penta_LL);
 
-        const auto bookname = book.substr(book.find_last_of("/\\") + 1);
+        auto bookname   = book;
+        std::size_t pos = bookname.find_last_of("/\\");
+
+        if (pos != std::string::npos) {
+            bookname = bookname.substr(pos + 1);
+        }
 
         // engine, engine2, tc, threads, hash, book
         auto line1 = fmt::format("Results of {} vs {} ({}, {}, {}, {}):", first, second, tc, threads, hash, book);
@@ -157,7 +162,7 @@ class Fastchess : public IOutput {
     }
 
     std::string getHash(const engine::UciEngine& engine) {
-        return fmt::format("{}", engine.getOption("Hash").value_or("NaN"));
+        return fmt::format("{}", engine.getOption("Hash").value_or(""));
     }
 
     bool report_penta_;

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -37,6 +37,8 @@ class Fastchess : public IOutput {
         int fixed_time2 = limit2.tc.fixed_time;
         int tc1 = limit1.tc.time;
         int tc2 = limit2.tc.time;
+        int inc1 = limit1.tc.increment;
+        int inc2 = limit2.tc.increment;
         int nodes1 = limit1.nodes;
         int nodes2 = limit2.nodes;
         int plies1 = limit1.plies;

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -1,7 +1,14 @@
 #pragma once
 
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+
 #include <elo/elo_pentanomial.hpp>
 #include <elo/elo_wdl.hpp>
+#include <engine/uci_engine.hpp>
 #include <matchmaking/output/output.hpp>
 #include <util/logger/logger.hpp>
 
@@ -11,13 +18,11 @@ class Fastchess : public IOutput {
    public:
     Fastchess(bool report_penta = true) : report_penta_(report_penta) {}
 
-    void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
-                       const std::string& second, 
-                       const std::vector<std::pair<std::string, std::string>>& options1, 
-                       const std::vector<std::pair<std::string, std::string>>& options2,
-                       const Limit& limit1, const Limit& limit2, const std::string& book) override {
+    void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first, const std::string& second,
+                       const std::pair<const engine::UciEngine&, const engine::UciEngine&>& engines,
+                       const std::string& book) override {
         std::cout << "--------------------------------------------------\n" << std::flush;
-        printElo(stats, first, second, options1, options2, limit1, limit2, book);
+        printElo(stats, first, second, engines, book);
         printSprt(sprt, stats);
         std::cout << "--------------------------------------------------\n" << std::flush;
     };
@@ -27,46 +32,9 @@ class Fastchess : public IOutput {
     }
 
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
-                  const std::vector<std::pair<std::string, std::string>>& options1, 
-                  const std::vector<std::pair<std::string, std::string>>& options2,
-                  const Limit& limit1, const Limit& limit2, const std::string& book) override {
+                  const std::pair<const engine::UciEngine&, const engine::UciEngine&>& engines,
+                  const std::string& book) override {
         std::unique_ptr<elo::EloBase> elo;
-        int movestogo1 = limit1.tc.moves;
-        int movestogo2 = limit2.tc.moves;
-        int fixed_time1 = limit1.tc.fixed_time;
-        int fixed_time2 = limit2.tc.fixed_time;
-        int time1 = limit1.tc.time;
-        int time2 = limit2.tc.time;
-        int inc1 = limit1.tc.increment;
-        int inc2 = limit2.tc.increment;
-        int nodes1 = limit1.nodes;
-        int nodes2 = limit2.nodes;
-        int plies1 = limit1.plies;
-        int plies2 = limit2.plies;
-        std::string threads1 = "{}";
-        std::string threads2 = "{}";
-        std::string hash1 = "{}";
-        std::string hash2 = "{}";
-        auto hash1it = std::find_if(options1.begin(), options1.end(),
-                           [](const std::pair<std::string, std::string>& element) {
-                               return element.first == "Hash";
-                           });
-        auto hash2it = std::find_if(options2.begin(), options2.end(),
-                           [](const std::pair<std::string, std::string>& element) {
-                               return element.first == "Hash";
-                           });
-        auto threads1it = std::find_if(options1.begin(), options1.end(),
-                           [](const std::pair<std::string, std::string>& element) {
-                               return element.first == "Threads";
-                           });
-        auto threads2it = std::find_if(options2.begin(), options2.end(),
-                           [](const std::pair<std::string, std::string>& element) {
-                               return element.first == "Threads";
-                           });
-        if (hash1it != options1.end()) hash1 = hash1it->second;
-        if (hash2it != options2.end()) hash2 = hash2it->second;
-        if (threads1it != options1.end()) threads1 = threads1it->second;
-        if (threads2it != options2.end()) threads2 = threads2it->second;
 
         if (report_penta_) {
             elo = std::make_unique<elo::EloPentanomial>(stats);
@@ -74,119 +42,43 @@ class Fastchess : public IOutput {
             elo = std::make_unique<elo::EloWDL>(stats);
         }
 
-        std::stringstream ss;
-        ss << first          //
-           << " vs "         //
-           << second         //
-           << " (";
+        auto timeFirst  = getTime(engines.first);
+        auto timeSecond = getTime(engines.second);
+        auto tc =
+            timeFirst == timeSecond ? fmt::format("{}", timeFirst) : fmt::format("{} - {}", timeFirst, timeSecond);
 
-        if (movestogo1 != 0)
-            ss << movestogo1 << "moves" << "/";
+        auto threadsFirst  = getThreads(engines.first);
+        auto threadsSecond = getThreads(engines.second);
+        auto threads       = threadsFirst == threadsSecond ? fmt::format("{}t", threadsFirst)
+                                                           : fmt::format("{}t - {}t", threadsFirst, threadsSecond);
 
-        if (time1 > 0)
-            ss << time1 / 1000.0 << "s";
-        else if (fixed_time1 > 0)
-            ss << fixed_time1 / 1000.0 << "s/move";
-        else if (plies1 > 0)
-            ss << plies1 << "plies";
-        else if (nodes1 > 0)
-            ss << nodes1 << "nodes";
+        auto hashFirst  = getHash(engines.first);
+        auto hashSecond = getHash(engines.second);
 
-        if (inc1 != 0)
-            ss << "+" << inc1 / 1000.0 << "s";
-       
-        if (time1 != time2 || movestogo1 != movestogo2 || inc1 != inc2 ||
-            fixed_time1 != fixed_time2 || plies1 != plies2 || nodes1 != nodes2) {
-             ss << " - ";
-           
-            if (movestogo2 != 0)
-                ss << movestogo2 << "moves" << "/";
-   
-            if (time2 > 0)
-                ss << time2 / 1000.0 << "s";
-            else if (fixed_time2 > 0)
-                ss << fixed_time2 / 1000.0 << "s/move";
-            else if (plies2 > 0)
-                ss << plies2 << "plies";
-            else if (nodes2 > 0)
-                ss << nodes2 << "nodes";
+        auto hash = hashFirst == hashSecond ? fmt::format("{}MB", hashFirst)
+                                            : fmt::format("{}MB - {}MB", hashFirst, hashSecond);
 
-            if (inc2 != 0)
-                ss << "+" << inc2 / 1000.0 << "s";
-        }
+        const auto games       = stats.wins + stats.losses + stats.draws;
+        const auto points      = stats.wins + 0.5 * stats.draws;
+        const auto pointsRatio = points / games * 100;
 
-        ss << ", "
-           << threads1
-           << "t";
-       
-        if (threads1 != threads2) {
-            ss << " - "
-               << threads2
-               << "t";
-        }
-
-        ss << ", "
-           << hash1
-           << "MB";
-
-        if (hash1 != hash2) {
-            ss << " - "
-               << hash2
-               << "MB";
-        }
-
-        std::size_t pos = book.find_last_of("/\\");
-        std::string bookname = book;
-        if (pos != std::string::npos) {
-            bookname = book.substr(pos + 1);
-        }
-       
-        if (!book.empty()) {
-            ss << ", "
-               << bookname;
-        }
-       
-        ss << "):\n"
-           << "Elo: "        //
-           << elo->getElo()  //
-           << ", nElo: "     //
-           << elo->nElo()    //
-           << "\n";          //
-
-        ss << "LOS: "                 //
-           << elo->los()              //
-           << ", DrawRatio: "         //
-           << elo->drawRatio(stats);  //
-
-        const double pairsRatio =
+        const auto pairsRatio =
             static_cast<double>(stats.penta_WW + stats.penta_WD) / (stats.penta_LD + stats.penta_LL);
-        if (report_penta_) {
-            ss << ", PairsRatio: " << std::fixed << std::setprecision(2) << pairsRatio << "\n";
-        } else {
-            ss << "\n";
-        }
 
-        const double points = stats.wins + 0.5 * stats.draws;
-        ss << "Games: "                                                                                       //
-           << stats.wins + stats.losses + stats.draws                                                         //
-           << ", Wins: "                                                                                      //
-           << stats.wins                                                                                      //
-           << ", Losses: "                                                                                    //
-           << stats.losses                                                                                    //
-           << ", Draws: "                                                                                     //
-           << stats.draws                                                                                     //
-           << std::fixed << std::setprecision(1) << ", Points: "                                              //
-           << points                                                                                          //
-           << " ("                                                                                            //
-           << std::fixed << std::setprecision(2) << points / (stats.wins + stats.losses + stats.draws) * 100  //
-           << " %)\n";
+        const auto bookname = book.substr(book.find_last_of("/\\") + 1);
 
-        if (report_penta_) {
-            ss << "Ptnml(0-2): "
-               << "[" << stats.penta_LL << ", " << stats.penta_LD << ", " << stats.penta_WL + stats.penta_DD << ", "
-               << stats.penta_WD << ", " << stats.penta_WW << "]\n";
-        }
-        std::cout << ss.str() << std::flush;
+        // engine, engine2, tc, threads, hash, book
+        auto line1 = fmt::format("Results of {} vs {} ({}, {}, {}, {}):", first, second, tc, threads, hash, book);
+        auto line2 = fmt::format("Elo: {}, nElo: {}", elo->getElo(), elo->nElo());
+        auto line3 =
+            fmt::format("LOS: {}, DrawRatio: {}, PairsRatio: {:.2f}", elo->los(), elo->drawRatio(stats), pairsRatio);
+        auto line4 = fmt::format("Games: {}, Wins: {}, Losses: {}, Draws: {}, Points: {:.1f} ({:.2f} %)", games,
+                                 stats.wins, stats.losses, stats.draws, points, pointsRatio);
+        auto line5 = fmt::format("Ptnml(0-2): [{}, {}, {}, {}, {}]", stats.penta_LL, stats.penta_LD,
+                                 stats.penta_WL + stats.penta_DD, stats.penta_WD, stats.penta_WW);
+        auto lines = fmt::format("{}\n{}\n{}\n{}\n{}", line1, line2, line3, line4, line5);
+
+        std::cout << lines << std::endl;
     }
 
     void printSprt(const SPRT& sprt, const Stats& stats) override {
@@ -243,6 +135,31 @@ class Fastchess : public IOutput {
     void endTournament() override { std::cout << "Tournament finished" << std::endl; }
 
    private:
+    std::string getTime(const engine::UciEngine& engine) {
+        if (engine.getConfig().limit.tc.time > 0) {
+            return fmt::format("{:.2g}{}", engine.getConfig().limit.tc.time / 1000.0,
+                               engine.getConfig().limit.tc.increment > 0
+                                   ? fmt::format("+{:.2g}", engine.getConfig().limit.tc.increment / 1000.0)
+                                   : "");
+        } else if (engine.getConfig().limit.tc.fixed_time > 0) {
+            return fmt::format("{:.2f}move", engine.getConfig().limit.tc.fixed_time / 1000.0);
+        } else if (engine.getConfig().limit.plies > 0) {
+            return fmt::format("{} plies", engine.getConfig().limit.plies);
+        } else if (engine.getConfig().limit.nodes > 0) {
+            return fmt::format("{} nodes", engine.getConfig().limit.nodes);
+        }
+
+        return "";
+    }
+
+    std::string getThreads(const engine::UciEngine& engine) {
+        return fmt::format("{}", engine.getOption("Threads").value_or("1"));
+    }
+
+    std::string getHash(const engine::UciEngine& engine) {
+        return fmt::format("{}", engine.getOption("Hash").value_or("NaN"));
+    }
+
     bool report_penta_;
 };
 

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -73,7 +73,7 @@ class Fastchess : public IOutput {
         }
 
         // engine, engine2, tc, threads, hash, book
-        auto line1 = fmt::format("Results of {} vs {} ({}, {}, {}, {}):", first, second, tc, threads, hash, book);
+        auto line1 = fmt::format("Results of {} vs {} ({}, {}, {}, {}):", first, second, tc, threads, hash, bookname);
         auto line2 = fmt::format("Elo: {}, nElo: {}", elo->getElo(), elo->nElo());
         auto line3 =
             fmt::format("LOS: {}, DrawRatio: {}, PairsRatio: {:.2f}", elo->los(), elo->drawRatio(stats), pairsRatio);

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -47,7 +47,7 @@ class Fastchess : public IOutput {
         if (inc1 != 0)
             ss << "+" << inc1 / 1000.0;
        
-        if (tc1 != tc2 && movestogo1 != movestogo2 && inc1 != inc2) {
+        if (tc1 != tc2 || movestogo1 != movestogo2 || inc1 != inc2) {
              ss << " - ";
            
             if (movestogo2 != 0)

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -75,8 +75,7 @@ class Fastchess : public IOutput {
         }
 
         std::stringstream ss;
-        ss << "Results of "  //
-           << first          //
+        ss << first          //
            << " vs "         //
            << second         //
            << " (";

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -17,7 +17,7 @@ class Fastchess : public IOutput {
                        std::vector<std::pair<std::string, std::string>>& options2,
                        Limit& limit1, Limit& limit2, const std::string& book) override {
         std::cout << "--------------------------------------------------\n" << std::flush;
-        printElo(stats, first, second, options1, options2, limit1, limit2);
+        printElo(stats, first, second, options1, options2, limit1, limit2, book);
         printSprt(sprt, stats);
         std::cout << "--------------------------------------------------\n" << std::flush;
     };

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -33,16 +33,16 @@ class Fastchess : public IOutput {
         std::unique_ptr<elo::EloBase> elo;
         int movestogo1 = limit1.tc.moves;
         int movestogo2 = limit2.tc.moves;
-        //int fixed_time1 = limit1.tc.fixed_time;
-        //int fixed_time2 = limit2.tc.fixed_time;
-        int tc1 = limit1.tc.time;
-        int tc2 = limit2.tc.time;
+        int fixed_time1 = limit1.tc.fixed_time;
+        int fixed_time2 = limit2.tc.fixed_time;
+        int time1 = limit1.tc.time;
+        int time2 = limit2.tc.time;
         int inc1 = limit1.tc.increment;
         int inc2 = limit2.tc.increment;
-        //int nodes1 = limit1.nodes;
-        //int nodes2 = limit2.nodes;
-        //int plies1 = limit1.plies;
-        //int plies2 = limit2.plies;
+        int nodes1 = limit1.nodes;
+        int nodes2 = limit2.nodes;
+        int plies1 = limit1.plies;
+        int plies2 = limit2.plies;
         std::string threads1 = "{}";
         std::string threads2 = "{}";
         std::string hash1 = "{}";
@@ -66,7 +66,7 @@ class Fastchess : public IOutput {
         if (hash1it != options1.end()) hash1 = hash1it->second;
         if (hash2it != options2.end()) hash2 = hash2it->second;
         if (threads1it != options1.end()) threads1 = threads1it->second;
-        if (threads2it != options2.end()) threads1 = threads2it->second;
+        if (threads2it != options2.end()) threads2 = threads2it->second;
 
         if (report_penta_) {
             elo = std::make_unique<elo::EloPentanomial>(stats);
@@ -82,27 +82,38 @@ class Fastchess : public IOutput {
            << " (";
 
         if (movestogo1 != 0)
-            ss << movestogo1 << "/";
+            ss << movestogo1 << "moves" << "/";
 
-        ss << tc1 / 1000.0;
+        if (time1 > 0)
+            ss << time1 / 1000.0 << "s";
+        else if (fixed_time1 > 0)
+            ss << fixed_time1 / 1000.0 << "s/move";
+        else if (plies1 > 0)
+            ss << plies1 << "plies";
+        else if (nodes1 > 0)
+            ss << nodes1 << "nodes";
 
         if (inc1 != 0)
-            ss << "+" << inc1 / 1000.0;
-
-        ss << "s";
+            ss << "+" << inc1 / 1000.0 << "s";
        
-        if (tc1 != tc2 || movestogo1 != movestogo2 || inc1 != inc2) {
+        if (time1 != time2 || movestogo1 != movestogo2 || inc1 != inc2 ||
+            fixed_time1 != fixed_time2 || plies1 != plies2 || nodes1 != nodes2) {
              ss << " - ";
            
             if (movestogo2 != 0)
-                ss << movestogo2 << "/";
+                ss << movestogo2 << "moves" << "/";
    
-            ss << tc2 / 1000.0;
-   
-            if (inc2 != 0)
-                ss << "+" << inc2 / 1000.0;
+            if (time2 > 0)
+                ss << time2 / 1000.0 << "s";
+            else if (fixed_time2 > 0)
+                ss << fixed_time2 / 1000.0 << "s/move";
+            else if (plies2 > 0)
+                ss << plies2 << "plies";
+            else if (nodes2 > 0)
+                ss << nodes2 << "nodes";
 
-            ss << "s";
+            if (inc2 != 0)
+                ss << "+" << inc2 / 1000.0 << "s";
         }
 
         ss << ", "

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -31,7 +31,7 @@ class Fastchess : public IOutput {
         int movestogo1 = limit1.tc.moves;
         int movestogo2 = limit2.tc.moves;
         int fixed_time1 = limit1.tc.fixed_time;
-        int fixed_time2 = limit2.tc.fixed_time
+        int fixed_time2 = limit2.tc.fixed_time;
         int tc1 = limit1.tc.time;
         int tc2 = limit2.tc.time;
         int nodes1 = limit1.nodes;
@@ -72,7 +72,7 @@ class Fastchess : public IOutput {
                 ss << "+" << inc2 / 1000.0;
         }
 
-        ss << ", "
+        ss << "s, "
            << threads1
            << "t";
        

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -88,6 +88,8 @@ class Fastchess : public IOutput {
 
         if (inc1 != 0)
             ss << "+" << inc1 / 1000.0;
+
+        ss << "s";
        
         if (tc1 != tc2 || movestogo1 != movestogo2 || inc1 != inc2) {
              ss << " - ";
@@ -99,9 +101,11 @@ class Fastchess : public IOutput {
    
             if (inc2 != 0)
                 ss << "+" << inc2 / 1000.0;
+
+            ss << "s";
         }
 
-        ss << "s, "
+        ss << ", "
            << threads1
            << "t";
        
@@ -120,7 +124,12 @@ class Fastchess : public IOutput {
                << hash2
                << "MB";
         }
-           
+
+        std::size_t pos = book.find_last_of("/\\");
+        if (pos != std::string::npos) {
+            book = book.substr(pos + 1);
+        }
+       
         if (!book.empty()) {
             ss << ", "
                << book;

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -126,13 +126,14 @@ class Fastchess : public IOutput {
         }
 
         std::size_t pos = book.find_last_of("/\\");
+        std::string bookname = book;
         if (pos != std::string::npos) {
-            book = book.substr(pos + 1);
+            bookname = book.substr(pos + 1);
         }
        
         if (!book.empty()) {
             ss << ", "
-               << book;
+               << bookname;
         }
        
         ss << "):\n"

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -23,7 +23,10 @@ class Fastchess : public IOutput {
         // do nothing
     }
 
-    void printElo(const Stats& stats, const std::string& first, const std::string& second) override {
+    void printElo(const Stats& stats, const std::string& first, const std::string& second,
+                  std::vector<std::pair<std::string, std::string>>& options1, 
+                  std::vector<std::pair<std::string, std::string>>& options2,
+                  Limit& limit1, Limit& limit2) override {
         std::unique_ptr<elo::EloBase> elo;
 
         if (report_penta_) {

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -36,6 +36,8 @@ class Fastchess : public IOutput {
         int tc2 = limit2.tc.time;
         int nodes1 = limit1.nodes;
         int nodes2 = limit2.nodes;
+        int plies1 = limit1.plies;
+        int plies2 = limit2.plies;
 
         if (report_penta_) {
             elo = std::make_unique<elo::EloPentanomial>(stats);

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -76,9 +76,9 @@ class Fastchess : public IOutput {
                                  stats.wins, stats.losses, stats.draws, points, pointsRatio);
         auto line5 = fmt::format("Ptnml(0-2): [{}, {}, {}, {}, {}]", stats.penta_LL, stats.penta_LD,
                                  stats.penta_WL + stats.penta_DD, stats.penta_WD, stats.penta_WW);
-        auto lines = fmt::format("{}\n{}\n{}\n{}\n{}", line1, line2, line3, line4, line5);
+        auto lines = fmt::format("{}\n{}\n{}\n{}\n{}\n", line1, line2, line3, line4, line5);
 
-        std::cout << lines << std::endl;
+        std::cout << lines << std::flush;
     }
 
     void printSprt(const SPRT& sprt, const Stats& stats) override {

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -37,7 +37,27 @@ class Fastchess : public IOutput {
            << first          //
            << " vs "         //
            << second         //
-           << ": \n";
+           << " (";
+
+        if (movestogo1 != 0)
+            ss << movestogo1 << "/";
+
+        ss << tc1 / 1000.0;
+
+        if (inc1 != 0)
+            ss << "+" << inc1 / 1000.0;
+
+        ss << ", "
+           << threads1
+           << "t - "
+           << threads2
+           << "t, "
+           << hash1
+           << "MB - "
+           << hash2
+           << "MB, "
+           << book
+           << "):\n";
 
         ss << "Elo: "        //
            << elo->getElo()  //

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -28,6 +28,7 @@ class Fastchess : public IOutput {
                   std::vector<std::pair<std::string, std::string>>& options2,
                   Limit& limit1, Limit& limit2) override {
         std::unique_ptr<elo::EloBase> elo;
+        int movestogo1 = limit1.movestogo
 
         if (report_penta_) {
             elo = std::make_unique<elo::EloPentanomial>(stats);

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -12,9 +12,12 @@ class Fastchess : public IOutput {
     Fastchess(bool report_penta = true) : report_penta_(report_penta) {}
 
     void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
-                       const std::string& second) override {
+                       const std::string& second, 
+                       std::vector<std::pair<std::string, std::string>>& options1, 
+                       std::vector<std::pair<std::string, std::string>>& options2,
+                       Limit& limit1, Limit& limit2, const std::string& book) override {
         std::cout << "--------------------------------------------------\n" << std::flush;
-        printElo(stats, first, second);
+        printElo(stats, first, second, options1, options2, limit1, limit2);
         printSprt(sprt, stats);
         std::cout << "--------------------------------------------------\n" << std::flush;
     };

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -13,9 +13,9 @@ class Fastchess : public IOutput {
 
     void printInterval(const SPRT& sprt, const Stats& stats, const std::string& first,
                        const std::string& second, 
-                       std::vector<std::pair<std::string, std::string>>& options1, 
-                       std::vector<std::pair<std::string, std::string>>& options2,
-                       Limit& limit1, Limit& limit2, const std::string& book) override {
+                       const std::vector<std::pair<std::string, std::string>>& options1, 
+                       const std::vector<std::pair<std::string, std::string>>& options2,
+                       const Limit& limit1, const Limit& limit2, const std::string& book) override {
         std::cout << "--------------------------------------------------\n" << std::flush;
         printElo(stats, first, second, options1, options2, limit1, limit2, book);
         printSprt(sprt, stats);
@@ -27,22 +27,22 @@ class Fastchess : public IOutput {
     }
 
     void printElo(const Stats& stats, const std::string& first, const std::string& second,
-                  std::vector<std::pair<std::string, std::string>>& options1, 
-                  std::vector<std::pair<std::string, std::string>>& options2,
-                  Limit& limit1, Limit& limit2, const std::string& book) override {
+                  const std::vector<std::pair<std::string, std::string>>& options1, 
+                  const std::vector<std::pair<std::string, std::string>>& options2,
+                  const Limit& limit1, const Limit& limit2, const std::string& book) override {
         std::unique_ptr<elo::EloBase> elo;
         int movestogo1 = limit1.tc.moves;
         int movestogo2 = limit2.tc.moves;
-        int fixed_time1 = limit1.tc.fixed_time;
-        int fixed_time2 = limit2.tc.fixed_time;
+        //int fixed_time1 = limit1.tc.fixed_time;
+        //int fixed_time2 = limit2.tc.fixed_time;
         int tc1 = limit1.tc.time;
         int tc2 = limit2.tc.time;
         int inc1 = limit1.tc.increment;
         int inc2 = limit2.tc.increment;
-        int nodes1 = limit1.nodes;
-        int nodes2 = limit2.nodes;
-        int plies1 = limit1.plies;
-        int plies2 = limit2.plies;
+        //int nodes1 = limit1.nodes;
+        //int nodes2 = limit2.nodes;
+        //int plies1 = limit1.plies;
+        //int plies2 = limit2.plies;
         std::string threads1 = "{}";
         std::string threads2 = "{}";
         std::string hash1 = "{}";

--- a/app/src/matchmaking/tournament/base/tournament.cpp
+++ b/app/src/matchmaking/tournament/base/tournament.cpp
@@ -71,7 +71,7 @@ void BaseTournament::playGame(const std::pair<EngineConfiguration, EngineConfigu
 
     Logger::trace("Playing game {} between {} and {}", game_id + 1, configs.first.name, configs.second.name);
 
-    start();
+    start({engine_one.get().get(), engine_two.get().get()});
 
     auto match = Match(tournament_options_, opening);
     match.start(engine_one.get().get(), engine_two.get().get(), core.get().cpus);
@@ -103,7 +103,7 @@ void BaseTournament::playGame(const std::pair<EngineConfiguration, EngineConfigu
         if (!tournament_options_.epd.file.empty())
             file_writer_epd->write(epd::EpdBuilder(match_data, tournament_options_).get());
 
-        finish({match_data}, match_data.reason);
+        finish({match_data}, match_data.reason, {engine_one.get().get(), engine_two.get().get()});
     }
 }
 

--- a/app/src/matchmaking/tournament/base/tournament.hpp
+++ b/app/src/matchmaking/tournament/base/tournament.hpp
@@ -65,8 +65,10 @@ class BaseTournament {
     // creates the matches
     virtual void create() = 0;
 
-    using start_callback    = std::function<void()>;
-    using finished_callback = std::function<void(const Stats &stats, const std::string &reason)>;
+    using start_callback = std::function<void(const std::pair<const engine::UciEngine &, const engine::UciEngine &> &)>;
+    using finished_callback =
+        std::function<void(const Stats &stats, const std::string &reason,
+                           const std::pair<const engine::UciEngine &, const engine::UciEngine &> &)>;
 
     // Function to save the config file
     void saveJson();

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -153,7 +153,10 @@ void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine
 
         Logger::info("SPRT test finished: {} {}", sprt_.getBounds(), sprt_.getElo());
         output_->printResult(stats, engine_configs[0].name, engine_configs[1].name);
-        output_->printInterval(sprt_, stats, engine_configs[0].name, engine_configs[1].name);
+        output_->printInterval(sprt_, stats, engine_configs[0].name, engine_configs[1].name, 
+                               engine_configs[0].options, engine_configs[1].options,
+                               engine_configs[0].limit, engine_configs[1].limit,
+                               tournament_options_.opening.file);
         output_->endTournament();
 
         stop();

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -115,7 +115,8 @@ void RoundRobin::create() {
             // penta stats.
             if ((report && ratinginterval_index % tournament_options_.ratinginterval == 0) ||
                 match_count_ + 1 == total_) {
-                output_->printInterval(sprt_, updated_stats, first.name, second.name);
+                output_->printInterval(sprt_, updated_stats, first.name, second.name, first.options, second.options, 
+                                       first.limit, second.limit, tournament_options_.opening.file);
             }
 
             updateSprtStatus({first, second});

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
@@ -34,7 +34,8 @@ class RoundRobin : public BaseTournament {
 
    private:
     // update the current running sprt. SPRT Config has to be valid.
-    void updateSprtStatus(const std::vector<EngineConfiguration> &engine_configs);
+    void updateSprtStatus(const std::vector<EngineConfiguration> &engine_configs,
+                          const std::pair<const engine::UciEngine &, const engine::UciEngine &> &engines);
 
     SPRT sprt_ = SPRT();
 


### PR DESCRIPTION
its done


![Screenshot 2024-06-22 032659](https://github.com/Disservin/fast-chess/assets/155860115/001e636e-4e16-4123-98f7-cc070ac666d0)

![Screenshot 2024-06-22 034953](https://github.com/Disservin/fast-chess/assets/155860115/b4f391ec-ce2a-4e6e-b005-6bb88f76eb5b)

the only thing left is the uci default values, for that you can just replace the placeholder values here:

![Screenshot 2024-06-22 035505](https://github.com/Disservin/fast-chess/assets/155860115/0c1ae1ba-866c-40fc-a982-c95c50efb456)

fix https://github.com/Disservin/fast-chess/issues/479