### PR TITLE
add statically linked zlib for CI release builds

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Building Fast-Chess
         run: |
-          make -j2 build=release
+          make -j2 build=release ZLIB=true
           strip ./fast-chess$EXT
           mv fast-chess$EXT fast-chess-$OS$EXT
           ./fast-chess* -version


### PR DESCRIPTION
https://github.com/Disservin/fast-chess/issues/482