### PR TITLE
fix: illegal moves when engine times out

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -203,46 +203,33 @@ bool Match::playMove(Player& us, Player& them) {
 
     const auto elapsed_millis = chrono::duration_cast<chrono::milliseconds>(t1 - t0).count();
 
-    // Illegal move
     const auto best_move = us.engine.bestmove();
     const auto move      = best_move ? uci::uciToMove(board_, *best_move) : Move::NO_MOVE;
     const auto legal     = isLegal(move);
 
+    const auto timeout = !us.updateTime(elapsed_millis);
+
     addMoveData(us, elapsed_millis, legal);
 
-    if (!legal) {
-        us.setLost();
-        them.setWon();
-
-        data_.termination = MatchTermination::ILLEGAL_MOVE;
-        data_.reason      = name + Match::ILLEGAL_MSG;
-
-        Logger::warn<true>("Warning; Illegal move {} played by {}", best_move ? *best_move : "<none>", name);
+    // there are two reasons why best_move could be empty
+    // 1. the engine crashed
+    // 2. the engine did not respond in time
+    // we report a loss on time when the engine didnt respond in time
+    // and otherwise an illegal move
+    if (best_move == std::nullopt) {
+        // Time forfeit
+        if (timeout) {
+            setEngineTimeoutStatus(us, them);
+        } else {
+            setEngineIllegalMoveStatus(us, them, best_move);
+        }
 
         return false;
     }
 
-    // Time forfeit
-    if (!us.updateTime(elapsed_millis)) {
-        us.setLost();
-        them.setWon();
-
-        data_.termination = MatchTermination::TIMEOUT;
-        data_.reason      = name + Match::TIMEOUT_MSG;
-
-        Logger::warn<true>("Warning; Engine {} loses on time", name);
-
-        // we send a stop command to the engine to prevent it from thinking
-        // and wait for a bestmove to appear
-
-        us.engine.writeEngine("stop");
-
-        if (!us.engine.outputIncludesBestmove()) {
-            // wait for bestmove, indefinitely
-            // is this a good idea? what if the engine is stuck?
-            us.engine.readEngine("bestmove", 0ms);
-        }
-
+    // illegal move
+    if (!legal) {
+        setEngineIllegalMoveStatus(us, them, best_move);
         return false;
     }
 
@@ -275,6 +262,40 @@ void Match::setEngineCrashStatus(Player& loser, Player& winner) {
 
     data_.termination = MatchTermination::DISCONNECT;
     data_.reason      = loser.engine.getConfig().name + Match::DISCONNECT_MSG;
+}
+
+void Match::setEngineTimeoutStatus(Player& loser, Player& winner) {
+    loser.setLost();
+    winner.setWon();
+
+    const auto name = loser.engine.getConfig().name;
+
+    data_.termination = MatchTermination::TIMEOUT;
+    data_.reason      = name + Match::TIMEOUT_MSG;
+
+    Logger::warn<true>("Warning; Engine {} loses on time", name);
+
+    // we send a stop command to the engine to prevent it from thinking
+    // and wait for a bestmove to appear
+
+    loser.engine.writeEngine("stop");
+
+    if (!loser.engine.outputIncludesBestmove()) {
+        // wait 10 seconds for the bestmove to appear
+        loser.engine.readEngine("bestmove", 1000ms * 10);
+    }
+}
+
+void Match::setEngineIllegalMoveStatus(Player& loser, Player& winner, const std::optional<std::string>& best_move) {
+    loser.setLost();
+    winner.setWon();
+
+    const auto name = loser.engine.getConfig().name;
+
+    data_.termination = MatchTermination::ILLEGAL_MOVE;
+    data_.reason      = name + Match::ILLEGAL_MSG;
+
+    Logger::warn<true>("Warning; Illegal move {} played by {}", best_move ? *best_move : "<none>", name);
 }
 
 bool Match::isUciMove(const std::string& move) noexcept {

--- a/app/src/matchmaking/match/match.hpp
+++ b/app/src/matchmaking/match/match.hpp
@@ -118,6 +118,8 @@ class Match {
 
    private:
     void setEngineCrashStatus(Player& loser, Player& winner);
+    void setEngineTimeoutStatus(Player& loser, Player& winner);
+    void setEngineIllegalMoveStatus(Player& loser, Player& winner, const std::optional<std::string>& best_move);
 
     static bool isUciMove(const std::string& move) noexcept;
     void verifyPvLines(const Player& us);


### PR DESCRIPTION
```
--------------------------------------------------
Results of engine1 vs engine2 (2+0.02, 1t, 16MB, book.epd):
Elo: -78.52 +/- 162.75, nElo: -86.86 +/- 160.50
LOS: 14.44 %, DrawRatio: 55.56 %, PairsRatio: 0.33
Games: 18, Wins: 7, Losses: 11, Draws: 0, Points: 7.0 (38.89 %)
Ptnml(0-2): [3, 0, 5, 0, 1]
LLR: -0.06 (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
Warning; No bestmove found in the last line from engine1
Warning; No bestmove found in the last line from engine1
Warning; No info line found in the last line which includes the score from engine1
Warning; No info line found in the last line which includes the score from engine1
Warning; No info line found in the last line which includes the score from engine1
Warning; No info string found in the last line from engine1 which includes the score
Warning; Engine engine1 loses on time
Finished game 10 (engine1 vs engine2): 0-1 {engine1 loses on time}
--------------------------------------------------
Results of engine1 vs engine2 (2+0.02, 1t, 16MB, book.epd):
Elo: -70.44 +/- 143.13, nElo: -81.89 +/- 152.27
LOS: 14.59 %, DrawRatio: 60.00 %, PairsRatio: 0.33
Games: 20, Wins: 8, Losses: 12, Draws: 0, Points: 8.0 (40.00 %)
Ptnml(0-2): [3, 0, 6, 0, 1]
LLR: -0.06 (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
Finished match.
Saved results.
```


fixes https://github.com/Disservin/fast-chess/issues/486
