### PR TITLE
refactor: time limit for tc should take precedence over st

### DIFF
--- a/app/src/time/timecontrol.cpp
+++ b/app/src/time/timecontrol.cpp
@@ -14,10 +14,10 @@
 namespace fast_chess {
 
 TimeControl::TimeControl(const Limits &limits) : limits_(limits) {
-    if (limits_.fixed_time != 0) {
-        time_left_ = limits_.fixed_time;
-    } else if (limits_.time != 0) {
+    if (limits_.time > 0) {
         time_left_ = limits_.time;
+    } else if (limits_.fixed_time > 0) {
+        time_left_ = limits_.fixed_time;
     } else {
         time_left_ = 0;
     }


### PR DESCRIPTION
say if someone does `-each tc=10+0.1 st=1` then the game manager should only care about enforcing timelosses for the tc, the fixed movetime should act as a time limit constraint for the engine internal only