### PR TITLE
fix: timelosses in fixed time mode when timemargin is not specified

### DIFF
--- a/app/src/time/timecontrol.cpp
+++ b/app/src/time/timecontrol.cpp
@@ -54,6 +54,9 @@ bool TimeControl::updateTime(const int64_t elapsed_millis) noexcept {
 
     time_left_ += limits_.increment;
 
+    if (limits_.fixed_time != 0)
+        time_left_ = limits_.fixed_time;
+    
     return true;
 }
 


### PR DESCRIPTION
basically we have a bug where game auto time losses if timemargin is not bigger than fixed_time because time_left_ is not reset after every move, this fixes that