### PR TITLE
feat: add WL/DD Ratio to fastchess output

### DIFF
--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -85,7 +85,7 @@ class Fastchess : public IOutput {
             auto line5 = fmt::format("Ptnml(0-2): [{}, {}, {}, {}, {}], WL/DD Ratio: {:.2f}", stats.penta_LL, stats.penta_LD,
                                      stats.penta_WL + stats.penta_DD, stats.penta_WD, stats.penta_WW, WLDDRatio);
 
-            return fmt::format("{}\n{}\n{}\n{}\n", line1, line2, line3, line4, line5);
+            return fmt::format("{}\n{}\n{}\n{}\n{}\n", line1, line2, line3, line4, line5);
         }
 
         return fmt::format("{}\n{}\n{}\n{}\n", line1, line2, line3, line4);

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -59,6 +59,7 @@ class Fastchess : public IOutput {
         const auto games       = stats.wins + stats.losses + stats.draws;
         const auto points      = stats.wins + 0.5 * stats.draws;
         const auto pointsRatio = points / games * 100;
+        const auto WLDDRatio   = static_cast<double>(stats.penta_WL) / stats.penta_DD;
 
         const auto pairsRatio =
             static_cast<double>(stats.penta_WW + stats.penta_WD) / (stats.penta_LD + stats.penta_LL);
@@ -78,9 +79,13 @@ class Fastchess : public IOutput {
             fmt::format("LOS: {}, DrawRatio: {}, PairsRatio: {:.2f}", elo->los(), elo->drawRatio(stats), pairsRatio);
         auto line4 = fmt::format("Games: {}, Wins: {}, Losses: {}, Draws: {}, Points: {:.1f} ({:.2f} %)", games,
                                  stats.wins, stats.losses, stats.draws, points, pointsRatio);
-        auto line5 = fmt::format("Ptnml(0-2): [{}, {}, {}, {}, {}]", stats.penta_LL, stats.penta_LD,
-                                 stats.penta_WL + stats.penta_DD, stats.penta_WD, stats.penta_WW);
-        auto lines = fmt::format("{}\n{}\n{}\n{}\n{}\n", line1, line2, line3, line4, line5);
+        auto line5 = fmt::format("Ptnml(0-2): [{}, {}, {}, {}, {}], WL/DD Ratio: {:.2f}", stats.penta_LL, stats.penta_LD,
+                                 stats.penta_WL + stats.penta_DD, stats.penta_WD, stats.penta_WW, WLDDRatio);
+        std::string lines;
+        if (report_penta_)
+            lines = fmt::format("{}\n{}\n{}\n{}\n{}\n", line1, line2, line3, line4, line5);
+        else
+            lines = fmt::format("{}\n{}\n{}\n{}\n", line1, line2, line3, line4);
 
         std::cout << lines << std::flush;
     }

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -80,15 +80,15 @@ class Fastchess : public IOutput {
             fmt::format("LOS: {}, DrawRatio: {}, PairsRatio: {:.2f}", elo->los(), elo->drawRatio(stats), pairsRatio);
         auto line4 = fmt::format("Games: {}, Wins: {}, Losses: {}, Draws: {}, Points: {:.1f} ({:.2f} %)", games,
                                  stats.wins, stats.losses, stats.draws, points, pointsRatio);
-        auto line5 = fmt::format("Ptnml(0-2): [{}, {}, {}, {}, {}], WL/DD Ratio: {:.2f}", stats.penta_LL, stats.penta_LD,
-                                 stats.penta_WL + stats.penta_DD, stats.penta_WD, stats.penta_WW, WLDDRatio);
-        std::string lines;
-        if (report_penta_)
-            lines = fmt::format("{}\n{}\n{}\n{}\n{}\n", line1, line2, line3, line4, line5);
-        else
-            lines = fmt::format("{}\n{}\n{}\n{}\n", line1, line2, line3, line4);
 
-        return lines;
+        if (report_penta_) {
+            auto line5 = fmt::format("Ptnml(0-2): [{}, {}, {}, {}, {}], WL/DD Ratio: {:.2f}", stats.penta_LL, stats.penta_LD,
+                                     stats.penta_WL + stats.penta_DD, stats.penta_WD, stats.penta_WW, WLDDRatio);
+
+            return fmt::format("{}\n{}\n{}\n{}\n", line1, line2, line3, line4, line5);
+        }
+
+        return fmt::format("{}\n{}\n{}\n{}\n", line1, line2, line3, line4);
     }
 
     std::string printSprt(const SPRT& sprt, const Stats& stats) override {


### PR DESCRIPTION
i think this is a useful stat for measuring if a book leans more to being too unbalanced or too balanced, if WL/DD>1 then we can infer that the book leans more to being unbalanced while WL/DD<1 means a book leans more to being balanced.
looks like this:
```
--------------------------------------------------
Results of random_move_1 vs random_move_2 (2+0.02, NULL, NULL, openings.pgn):
Elo: -34.86 +/- 62.20, nElo: -122.84 +/- 215.34
LOS: 13.18 %, DrawRatio: 80.00 %, PairsRatio: 0.00
Games: 10, Wins: 1, Losses: 2, Draws: 7, Points: 4.5 (45.00 %)
Ptnml(0-2): [0, 1, 4, 0, 0], WL/DD Ratio: 0.33
--------------------------------------------------
```