### PR TITLE
fix: make sprt result format consistent with cutechess output

### DIFF
--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -35,8 +35,22 @@ class Cutechess : public IOutput {
 
     std::string printSprt(const SPRT& sprt, const Stats& stats) override {
         if (sprt.isEnabled()) {
-            auto fmt = fmt::format("LLR: {:.2f} {} {}\n", sprt.getLLR(stats.wins, stats.draws, stats.losses),
-                                   sprt.getBounds(), sprt.getElo());
+            double lowerBound = sprt.getLowerBound();
+            double upperBound = sprt.getUpperBound();
+            double llr = sprt.getLLR(stats.wins, stats.draws, stats.losses);
+            double percentage = llr < 0 ? llr / lowerBound * 100 : llr / upperBound * 100;
+           
+            std::string result;
+            if (llr >= upperBound) {
+                result = " - H1 was accepted";
+            } else if (llr < lowerBound) {
+                result = " - H0 was accepted";
+            } else {
+                result = "";
+            }
+           
+            std::string fmt = fmt::format("SPRT: llr {.2f} ({.1f}%), lbound {}, ubound {}{}\n", 
+                              llr, percentage, lowerBound, upperBound, result);
 
             return fmt;
         }

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -45,14 +45,9 @@ class Cutechess : public IOutput {
                 result = " - H1 was accepted";
             } else if (llr < lowerBound) {
                 result = " - H0 was accepted";
-            } else {
-                result = "";
             }
-           
-            std::string fmt = fmt::format("SPRT: llr {.2f} ({.1f}%), lbound {}, ubound {}{}\n", 
-                              llr, percentage, lowerBound, upperBound, result);
 
-            return fmt;
+            return fmt::format("SPRT: llr {.2f} ({.1f}%), lbound {}, ubound {}{}\n", llr, percentage, lowerBound, upperBound, result);
         }
         return "";
     };

--- a/app/src/matchmaking/sprt/sprt.cpp
+++ b/app/src/matchmaking/sprt/sprt.cpp
@@ -160,6 +160,14 @@ std::string SPRT::getElo() const noexcept {
     return ss.str();
 }
 
+double SPRT::getLowerBound() const noexcept {
+    return elo0_;
+}
+
+double SPRT::getUpperBound() const noexcept {
+    return elo1_;
+}
+
 bool SPRT::isEnabled() const noexcept { return enabled_; }
 
 }  // namespace fast_chess

--- a/app/src/matchmaking/sprt/sprt.hpp
+++ b/app/src/matchmaking/sprt/sprt.hpp
@@ -28,6 +28,8 @@ class SPRT {
     [[nodiscard]] SPRTResult getResult(double llr) const noexcept;
     [[nodiscard]] std::string getBounds() const noexcept;
     [[nodiscard]] std::string getElo() const noexcept;
+    [[nodiscard]] double getLowerBound() const noexcept;
+    [[nodiscard]] double getUpperBound() const noexcept;
 
    private:
     double lower_ = 0.0;


### PR DESCRIPTION
looks like this for cutechess output:
```
SPRT: llr 2.98 (101.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```