### PR TITLE
more useful warnings

### DIFF
--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -55,7 +55,7 @@ bool UciEngine::position(const std::vector<std::string> &moves, const std::strin
     return writeEngine(position);
 }
 
-std::string UciEngine::goinput(const TimeControl &our_tc, const TimeControl &enemy_tc, chess::Color stm) {
+std::string UciEngine::go(const TimeControl &our_tc, const TimeControl &enemy_tc, chess::Color stm) {
     std::stringstream input;
     input << "go";
 
@@ -86,10 +86,6 @@ std::string UciEngine::goinput(const TimeControl &our_tc, const TimeControl &ene
     }
 
     return input.str();
-}
-
-bool UciEngine::go(const std::string &input) {
-    return writeEngine(input);
 }
 
 bool UciEngine::ucinewgame() {

--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -55,7 +55,7 @@ bool UciEngine::position(const std::vector<std::string> &moves, const std::strin
     return writeEngine(position);
 }
 
-bool UciEngine::go(const TimeControl &our_tc, const TimeControl &enemy_tc, chess::Color stm) {
+std::string UciEngine::goinput(const TimeControl &our_tc, const TimeControl &enemy_tc, chess::Color stm) {
     std::stringstream input;
     input << "go";
 
@@ -85,7 +85,11 @@ bool UciEngine::go(const TimeControl &our_tc, const TimeControl &enemy_tc, chess
         }
     }
 
-    return writeEngine(input.str());
+    return input.str();
+}
+
+bool UciEngine::go(std::string &input) {
+    return writeEngine(input);
 }
 
 bool UciEngine::ucinewgame() {

--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -88,7 +88,7 @@ std::string UciEngine::goinput(const TimeControl &our_tc, const TimeControl &ene
     return input.str();
 }
 
-bool UciEngine::go(std::string &input) {
+bool UciEngine::go(const std::string &input) {
     return writeEngine(input);
 }
 

--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -48,8 +48,7 @@ class UciEngine : protected process::Process {
     // Sends "position" to the engine and waits for a response.
     [[nodiscard]] bool position(const std::vector<std::string> &moves, const std::string &fen);
 
-    [[nodiscard]] std::string goinput(const TimeControl &our_tc, const TimeControl &enemy_tc, chess::Color stm);
-    [[nodiscard]] bool go(const std::string &input);
+    [[nodiscard]] std::string go(const TimeControl &our_tc, const TimeControl &enemy_tc, chess::Color stm);
 
     void quit();
 

--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -48,7 +48,8 @@ class UciEngine : protected process::Process {
     // Sends "position" to the engine and waits for a response.
     [[nodiscard]] bool position(const std::vector<std::string> &moves, const std::string &fen);
 
-    [[nodiscard]] bool go(const TimeControl &our_tc, const TimeControl &enemy_tc, chess::Color stm);
+    [[nodiscard]] std::string goinput(const TimeControl &our_tc, const TimeControl &enemy_tc, chess::Color stm);
+    [[nodiscard]] bool go(const std::string &input);
 
     void quit();
 

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -276,9 +276,10 @@ void Match::setEngineCrashStatus(Player& loser, Player& winner, const std::strin
     auto fmt      = fmt::format("Warning; Engine {} disconnected", name);
     auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
     auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
-    auto fmt3     = fmt::format("{}", go_string.empty() ? "" : fmt::format("Command; {}", go_string));
+    auto fmt3     = fmt::format("Command; {}", go_string);
+    auto message  = go_string.empty() ? fmt : fmt::format(fmt + "\n" + fmt2 + "\n" + fmt3)
 
-    Logger::warn<true>(fmt + "\n" + fmt2 + "\n" + fmt3);
+    Logger::warn<true>(message);
 }
 
 void Match::setEngineTimeoutStatus(Player& loser, Player& winner, const std::string &startpos, 
@@ -294,7 +295,7 @@ void Match::setEngineTimeoutStatus(Player& loser, Player& winner, const std::str
     auto fmt      = fmt::format("Warning; Engine {} loses on time", name);
     auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
     auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
-    auto fmt3     = fmt::format("{}", go_string.empty() ? "" : fmt::format("Command; {}", go_string));
+    auto fmt3     = fmt::format("Command; {}", go_string);
 
     Logger::warn<true>(fmt + "\n" + fmt2 + "\n" + fmt3);
 
@@ -322,7 +323,7 @@ void Match::setEngineIllegalMoveStatus(Player& loser, Player& winner, const std:
     auto fmt      = fmt::format("Warning; Illegal move {} played by {}", best_move ? *best_move : "<none>", name);
     auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
     auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
-    auto fmt3     = fmt::format("{}", go_string.empty() ? "" : fmt::format("Command; {}", go_string));
+    auto fmt3     = fmt::format("Command; {}", go_string);
 
     Logger::warn<true>(fmt + "\n" + fmt2 + "\n" + fmt3);
 }

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -268,7 +268,7 @@ void Match::setEngineCrashStatus(Player& loser, Player& winner) {
 
     const auto name = loser.engine.getConfig().name;
     data_.termination = MatchTermination::DISCONNECT;
-    data_.reason      = loser.engine.getConfig().name + Match::DISCONNECT_MSG;
+    data_.reason      = name + Match::DISCONNECT_MSG;
 
     Logger::warn<true>("Warning; Engine {} disconnected", name);
 }

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -277,7 +277,7 @@ void Match::setEngineCrashStatus(Player& loser, Player& winner, const std::strin
     auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
     auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
     auto fmt3     = fmt::format("Command; {}", go_string);
-    auto message  = go_string.empty() ? fmt : fmt::format(fmt + "\n" + fmt2 + "\n" + fmt3)
+    auto message  = go_string.empty() ? fmt : fmt::format(fmt + "\n" + fmt2 + "\n" + fmt3);
 
     Logger::warn<true>(message);
 }

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -274,7 +274,7 @@ void Match::setEngineCrashStatus(Player& loser, Player& winner, const std::strin
     data_.termination = MatchTermination::DISCONNECT;
     data_.reason      = name + Match::DISCONNECT_MSG;
 
-    auto fmt      = fmt::format("Warning; Engine {} disconnected", name);
+    auto fmt      = fmt::format("Warning; Engine {} disconnects", name);
     auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
     auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
     auto fmt3     = fmt::format("Command; {}", go_string);

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -266,8 +266,11 @@ void Match::setEngineCrashStatus(Player& loser, Player& winner) {
 
     crash_or_disconnect_ = true;
 
+    const auto name = loser.engine.getConfig().name;
     data_.termination = MatchTermination::DISCONNECT;
     data_.reason      = loser.engine.getConfig().name + Match::DISCONNECT_MSG;
+
+    Logger::warn<true>("Warning; Engine {} disconnected", name);
 }
 
 void Match::setEngineTimeoutStatus(Player& loser, Player& winner) {

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -273,9 +273,12 @@ void Match::setEngineCrashStatus(Player& loser, Player& winner, const std::strin
     data_.termination = MatchTermination::DISCONNECT;
     data_.reason      = name + Match::DISCONNECT_MSG;
 
+    auto moves = uci_moves;
+    if (moves.size() >= 1) moves.pop_back();
+
     auto fmt      = fmt::format("Warning; Engine {} disconnected", name);
     auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
-    auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
+    auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(moves, " "));
     auto fmt3     = fmt::format("Command; {}", go_string);
     auto message  = go_string.empty() ? fmt : fmt::format(fmt + "\n" + fmt2 + "\n" + fmt3);
 
@@ -292,9 +295,12 @@ void Match::setEngineTimeoutStatus(Player& loser, Player& winner, const std::str
     data_.termination = MatchTermination::TIMEOUT;
     data_.reason      = name + Match::TIMEOUT_MSG;
 
+    auto moves = uci_moves;
+    if (moves.size() >= 1) moves.pop_back();
+
     auto fmt      = fmt::format("Warning; Engine {} loses on time", name);
     auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
-    auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
+    auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(moves, " "));
     auto fmt3     = fmt::format("Command; {}", go_string);
 
     Logger::warn<true>(fmt + "\n" + fmt2 + "\n" + fmt3);
@@ -320,9 +326,12 @@ void Match::setEngineIllegalMoveStatus(Player& loser, Player& winner, const std:
     data_.termination = MatchTermination::ILLEGAL_MOVE;
     data_.reason      = name + Match::ILLEGAL_MSG;
 
+    auto moves = uci_moves;
+    if (moves.size() >= 1) moves.pop_back();
+
     auto fmt      = fmt::format("Warning; Illegal move {} played by {}", best_move ? *best_move : "<none>", name);
     auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
-    auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
+    auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(moves, " "));
     auto fmt3     = fmt::format("Command; {}", go_string);
 
     Logger::warn<true>(fmt + "\n" + fmt2 + "\n" + fmt3);

--- a/app/src/matchmaking/match/match.hpp
+++ b/app/src/matchmaking/match/match.hpp
@@ -117,9 +117,12 @@ class Match {
     [[nodiscard]] bool isCrashOrDisconnect() const noexcept { return crash_or_disconnect_; }
 
    private:
-    void setEngineCrashStatus(Player& loser, Player& winner);
-    void setEngineTimeoutStatus(Player& loser, Player& winner);
-    void setEngineIllegalMoveStatus(Player& loser, Player& winner, const std::optional<std::string>& best_move);
+    void setEngineCrashStatus(Player& loser, Player& winner, const std::string &startpos, 
+                              const std::vector<std::string> &uci_moves, const std::string &go_string);
+    void setEngineTimeoutStatus(Player& loser, Player& winner, const std::string &startpos, 
+                                const std::vector<std::string> &uci_moves, const std::string &go_string);
+    void setEngineIllegalMoveStatus(Player& loser, Player& winner, const std::optional<std::string>& best_move, 
+                                    const std::string &startpos, const std::vector<std::string> &uci_moves, const std::string &go_string);
 
     static bool isUciMove(const std::string& move) noexcept;
     void verifyPvLines(const Player& us);


### PR DESCRIPTION
add the position fen and the command that triggered the illegal move/disconnect/timeout, allows the user to fully replicate it
```
[WARN  ] [04:17:02.236907] <  3> fastchess --- Warning; Illegal move b5e8 played by Engine2
From; position fen r2qk1nr/1bp1ppb1/ppnp2pp/1B6/3PPB2/2N2N2/PPPQ1PPP/2KR3R w kq - 0 9 moves b5c6 b7c6 d4d5 c6b7 e4e5 d8d7 d2e2 e8c8 h2h3 h6h5 h1e1 g8h6 c1b1 h6f5 f4h2 h8f8 a2a4 d8e8 e2c4 c8b8 c4b3 g6g5 a4a5 g5g4 f3g5 g4g3 f2g3 g7e5 a5b6 c7b6 e1e5 
Command; go wtime 4609 btime 4717 winc 100 binc 100
```