### PR TITLE
fix: missing parenthesis on validateEnginePath

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -160,7 +160,7 @@ void parseEngineKeyValues(EngineConfiguration &engineConfig, const std::string &
 
 void validateEnginePath(std::string dir, std::string &cmd) {
     // engine path with dir
-    auto engine_path = dir == "." ? "" : dir + cmd;
+    auto engine_path = (dir == "." ? "" : dir) + cmd;
 
 #ifndef NO_STD_FILESYSTEM
     if (!std::filesystem::exists(engine_path)) {


### PR DESCRIPTION
missing parenthesis for the engine path validation https://github.com/Disservin/fast-chess/blob/2a4ffaf57857df102dad4a1efb51106190fbd0c7/app/src/engine/uci_engine.cpp#L183

issue https://github.com/Disservin/fast-chess/issues/528