### PR TITLE
Fishtest fix

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -26,5 +26,7 @@ int main(int argc, char const *argv[]) {
 
     stopProcesses();
 
+    Logger::info("Finished match");
+
     return 0;
 }

--- a/app/src/matchmaking/tournament/tournament_manager.hpp
+++ b/app/src/matchmaking/tournament/tournament_manager.hpp
@@ -13,7 +13,7 @@ class TournamentManager {
                       const stats_map &results);
 
     ~TournamentManager() {
-        Logger::info("Finished match.");
+        Logger::trace("Finished tournament.");
         stop();
     }
 

--- a/app/src/types/tournament_options.hpp
+++ b/app/src/types/tournament_options.hpp
@@ -92,16 +92,18 @@ struct Tournament {
 #ifdef USE_CUTE
     // output format, fastchess or cutechess
     OutputType output = OutputType::CUTECHESS;
+    int autosaveinterval = 0;
+    int ratinginterval   = 0;
 #else
     // output format, fastchess or cutechess
     OutputType output = OutputType::FASTCHESS;
+    int autosaveinterval = 20;
+    int ratinginterval   = 10;
 #endif
 
     uint64_t seed = 951356066;
 
-    int ratinginterval   = 10;
     int scoreinterval    = 1;
-    int autosaveinterval = 20;
 
     int games       = 2;
     int rounds      = 2;


### PR DESCRIPTION
move "Finished match" to after process have been stopped as it signals the program stopping for fishtest and also disable autosave and ratinginterval for USE_CUTE build