### PR TITLE
fix: use the correct path for validate engines

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -161,7 +161,7 @@ void parseEngineKeyValues(EngineConfiguration &engineConfig, const std::string &
 void validateEnginePath([[maybe_unused]] std::string dir, [[maybe_unused]] std::string &cmd) {
 #ifndef NO_STD_FILESYSTEM
     // engine path with dir
-    auto p = std::filesystem::path(config_.dir) / std::filesystem::path(config_.cmd);
+    auto p = std::filesystem::path(dir) / std::filesystem::path(cmd);
     auto engine_path   = p.string();
 
     if (!std::filesystem::exists(engine_path)) {

--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -161,7 +161,8 @@ void parseEngineKeyValues(EngineConfiguration &engineConfig, const std::string &
 void validateEnginePath([[maybe_unused]] std::string dir, [[maybe_unused]] std::string &cmd) {
 #ifndef NO_STD_FILESYSTEM
     // engine path with dir
-    auto engine_path = (dir == "." ? "" : dir) + cmd;
+    auto p = std::filesystem::path(config_.dir) / std::filesystem::path(config_.cmd);
+    auto engine_path   = p.string();
 
     if (!std::filesystem::exists(engine_path)) {
         // append .exe to cmd if it is missing on windows


### PR DESCRIPTION
based on this https://github.com/Disservin/fast-chess/blob/450d70a9fa4773c0e1cac383fc13dce220ab0b57/app/src/engine/uci_engine.cpp#L185-L189