### PR TITLE
fix: avoid chaotic game output

### DIFF
--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -71,6 +71,13 @@ void RoundRobin::create() {
             const auto& cfg = config::TournamentConfig.get();
             bool report     = true;
 
+            // lock to avoid chaotic output, i.e.
+            // Finished game 187 (Engine1 vs Engine2): 0-1 {White loses on time}
+            // Finished game 186 (Engine2 vs Engine1): 0-1 {White loses on time}
+            // Score of Engine1 vs Engine2: 95 - 92 - 0  [0.508] 187
+            // Score of Engine1 vs Engine2: 94 - 92 - 0  [0.505] 186
+            std::lock_guard<std::mutex> lock(output_mutex_);
+
             if (cfg.report_penta)
                 report = result_.updatePairStats(configs, stats, round_id);
             else {

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
@@ -22,7 +22,7 @@ extern std::atomic_bool stop;
 
 class RoundRobin : public BaseTournament {
    public:
-    explicit RoundRobin(const stats_map &results);
+    explicit RoundRobin(const stats_map& results);
 
     // starts the round robin
     void start() override;
@@ -33,10 +33,11 @@ class RoundRobin : public BaseTournament {
 
    private:
     // update the current running sprt. SPRT Config has to be valid.
-    void updateSprtStatus(const std::vector<EngineConfiguration> &engine_configs,
-                          const std::pair<const engine::UciEngine &, const engine::UciEngine &> &engines);
+    void updateSprtStatus(const std::vector<EngineConfiguration>& engine_configs, const engines& engines);
 
     SPRT sprt_ = SPRT();
+
+    std::mutex output_mutex_;
 
     // number of games to be played
     std::atomic<uint64_t> total_ = 0;


### PR DESCRIPTION
tested at `-each tc=0.1+0.001`

```
Finished game 719 (sf1 vs sf2): 1-0 {White mates}
Finished game 765 (sf1 vs sf2): 1-0 {White mates}
Score of sf1 vs sf2: 322 - 336 - 83  [0.491] 741
Score of sf1 vs sf2: 323 - 336 - 83  [0.491] 742
```

fixes https://github.com/Disservin/fast-chess/issues/554