### PR TITLE
refactor: print "Finished game ..." alongside the scoreline to prevent chaotic output

### DIFF
--- a/app/src/matchmaking/output/output.hpp
+++ b/app/src/matchmaking/output/output.hpp
@@ -34,7 +34,7 @@ class IOutput {
     };
 
     // Print current H2H score result stats.
-    virtual void printResult(const Stats& stats, const std::string& first, const std::string& second) = 0;
+    virtual std::string printResult(const Stats& stats, const std::string& first, const std::string& second) = 0;
 
     // Print current H2H elo stats.
     virtual std::string printElo(const Stats& stats, const std::string& first, const std::string& second,
@@ -48,8 +48,8 @@ class IOutput {
                            std::size_t current_game_count, std::size_t max_game_count) = 0;
 
     // Print game end.
-    virtual void endGame(const GamePair<EngineConfiguration, EngineConfiguration>& configs, const Stats& stats,
-                         const std::string& annotation, std::size_t id) = 0;
+    virtual std::string endGame(const GamePair<EngineConfiguration, EngineConfiguration>& configs, const Stats& stats,
+                                const std::string& annotation, std::size_t id) = 0;
 
     // Print tournament end.
     virtual void endTournament() = 0;

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -60,12 +60,12 @@ class Cutechess : public IOutput {
         std::cout << fmt << std::flush;
     }
 
-    void endGame(const GamePair<EngineConfiguration, EngineConfiguration>& configs, const Stats& stats,
+    std::string endGame(const GamePair<EngineConfiguration, EngineConfiguration>& configs, const Stats& stats,
                  const std::string& annotation, std::size_t id) override {
         auto fmt = fmt::format("Finished game {} ({} vs {}): {} {{{}}}\n", id, configs.white.name, configs.black.name,
                                formatStats(stats), annotation);
 
-        std::cout << fmt << std::flush;
+        return fmt;
     }
 
     void endTournament() override { std::cout << "Tournament finished" << std::endl; }

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -13,13 +13,13 @@ class Cutechess : public IOutput {
         std::cout << printElo(stats, first, second, engines, book) << printSprt(sprt, stats) << std::flush;
     };
 
-    void printResult(const Stats& stats, const std::string& first, const std::string& second) override {
+    std::string printResult(const Stats& stats, const std::string& first, const std::string& second) override {
         const elo::EloWDL elo(stats);
 
         auto fmt = fmt::format("Score of {} vs {}: {} - {} - {}  [{}] {}\n", first, second, stats.wins, stats.losses,
                                stats.draws, elo.printScore(), stats.wins + stats.losses + stats.draws);
 
-        std::cout << fmt << std::flush;
+        return fmt;
     }
 
     std::string printElo(const Stats& stats, const std::string&, const std::string&, const engines&,

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -114,12 +114,12 @@ class Fastchess : public IOutput {
         std::cout << fmt << std::flush;
     }
 
-    void endGame(const GamePair<EngineConfiguration, EngineConfiguration>& configs, const Stats& stats,
+    std::string endGame(const GamePair<EngineConfiguration, EngineConfiguration>& configs, const Stats& stats,
                  const std::string& annotation, std::size_t id) override {
         auto fmt = fmt::format("Finished game {} ({} vs {}): {} {{{}}}\n", id, configs.white.name, configs.black.name,
                                formatStats(stats), annotation);
 
-        std::cout << fmt << std::flush;
+        return fmt;
     }
 
     void endTournament() override { std::cout << "Tournament finished" << std::endl; }

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -26,8 +26,9 @@ class Fastchess : public IOutput {
                   << std::flush;
     };
 
-    void printResult(const Stats&, const std::string&, const std::string&) override {
+    std::string printResult(const Stats&, const std::string&, const std::string&) override {
         // do nothing
+        return "";
     }
 
     std::string printElo(const Stats& stats, const std::string& first, const std::string& second,

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -65,7 +65,7 @@ void RoundRobin::create() {
         // callback functions, do not capture by reference
         const auto finish = [this, configs, first, second, game_id, round_id](
                                 const Stats& stats, const std::string& reason, const engines& engines) {
-            output_->endGame(configs, stats, reason, game_id);
+            std::string finish_message = output_->endGame(configs, stats, reason, game_id);
 
             const auto& cfg = config::TournamentConfig.get();
 
@@ -86,8 +86,10 @@ void RoundRobin::create() {
 
             // print score result based on scoreinterval if output format is cutechess
             if ((scoreinterval_index % cfg.scoreinterval == 0) || match_count_ + 1 == total_) {
-                output_->printResult(updated_stats, first.name, second.name);
+                finish_message += output_->printResult(updated_stats, first.name, second.name);
             }
+
+            std::cout << finish_message << std::flush;
 
             // Only print the interval if the pair is complete or we are not tracking
             // penta stats.

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -65,7 +65,6 @@ void RoundRobin::create() {
         // callback functions, do not capture by reference
         const auto finish = [this, configs, first, second, game_id, round_id](
                                 const Stats& stats, const std::string& reason, const engines& engines) {
-
             const auto& cfg = config::TournamentConfig.get();
 
             // lock to avoid chaotic output, i.e.

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -65,7 +65,6 @@ void RoundRobin::create() {
         // callback functions, do not capture by reference
         const auto finish = [this, configs, first, second, game_id, round_id](
                                 const Stats& stats, const std::string& reason, const engines& engines) {
-            std::string finish_message = output_->endGame(configs, stats, reason, game_id);
 
             const auto& cfg = config::TournamentConfig.get();
 
@@ -75,6 +74,8 @@ void RoundRobin::create() {
             // Score of Engine1 vs Engine2: 95 - 92 - 0  [0.508] 187
             // Score of Engine1 vs Engine2: 94 - 92 - 0  [0.505] 186
             std::lock_guard<std::mutex> lock(output_mutex_);
+            
+            std::string finish_message = output_->endGame(configs, stats, reason, game_id);
 
             bool report = cfg.report_penta ? scoreboard_.updatePair(configs, stats, round_id)
                                            : scoreboard_.updateNonPair(configs, stats);

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -130,7 +130,7 @@ void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine
         atomic::stop = true;
 
         Logger::info("SPRT test finished: {} {}", sprt_.getBounds(), sprt_.getElo());
-        output_->printResult(stats, engine_configs[0].name, engine_configs[1].name);
+        std::cout << output_->printResult(stats, engine_configs[0].name, engine_configs[1].name) << std::flush;
         output_->printInterval(sprt_, stats, engine_configs[0].name, engine_configs[1].name, engines,
                                config::TournamentConfig.get().opening.file);
         output_->endTournament();


### PR DESCRIPTION
prevent cases where finished game is printed twice before the scoreline, as this may affect fishtest parsing.

prevents this:
```
Finished game 64 (Engine2 vs Engine1): 1-0 {Black loses on time}
Finished game 63 (Engine1 vs Engine2): 1-0 {Black loses on time}
Score of Engine1 vs Engine2: 38 - 25 - 0  [0.603] 63
Started game 67 of 100 (Engine1 vs Engine2)
Score of Engine1 vs Engine2: 39 - 25 - 0  [0.609] 64
```