### PR TITLE
refactor: move adjudication check after gameover checks

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -165,6 +165,10 @@ bool Match::playMove(Player& us, Player& them) {
         return false;
     }
 
+    if (adjudicate(us, them)) {
+        return false;
+    }
+
     // disconnect
     if (!us.engine.isready()) {
         setEngineCrashStatus(us, them);
@@ -261,7 +265,7 @@ bool Match::playMove(Player& us, Player& them) {
     resign_tracker_.update(score, type, ~board_.sideToMove());
     maxmoves_tracker_.update(score, type);
 
-    return !adjudicate(us, them);
+    return true;
 }
 
 bool Match::isLegal(Move move) const noexcept {


### PR DESCRIPTION
should fix 

> The other one is: 
```
< Finished game 2 (sf_2 vs sf_1): 1/2-1/2 {Draw by 3-fold repetition}
---
> Finished game 2 (sf_2 vs sf_1): 1/2-1/2 {Draw by adjudication}
```

Here it looks like in cutechess the actual game status is checked first, while the adjudication comes afterwards. (The game does end in a real 3-fold).