### PR TITLE
refactor: set default log level to trace

### DIFF
--- a/app/src/util/logger/logger.cpp
+++ b/app/src/util/logger/logger.cpp
@@ -14,7 +14,7 @@
 namespace fast_chess {
 
 bool Logger::compress_               = false;
-Logger::Level Logger::level_         = Logger::Level::WARN;
+Logger::Level Logger::level_         = Logger::Level::TRACE;
 std::atomic_bool Logger::should_log_ = false;
 
 std::mutex Logger::log_mutex_;

--- a/man
+++ b/man
@@ -156,8 +156,8 @@ OPTIONS
             might lead to timeouts for very short time controls, to counteract this set it to false.
 
             LEVEL
-                trace
-                warn (default)
+                trace (default)
+                warn
                 info 
                 err
                 fatal


### PR DESCRIPTION
i think trace provides a lot of useful information for debugging, and its what most of the log consists of, so i feel its better to set it as the default level