### PR TITLE
refactor: make opening order mandatory for USE_CUTE

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -276,6 +276,9 @@ void parseOpening(const std::vector<std::string> &params, ArgumentData &argument
             OptionsParser::throwMissing("openings", key, value);
         }
     });
+    if (argument_data.tournament_config.opening.order == OrderType::NONE) {
+        throw std::runtime_error("Opening order not specified.");
+    }
 }
 
 void parseSprt(const std::vector<std::string> &params, ArgumentData &argument_data) {

--- a/app/src/types/enums.hpp
+++ b/app/src/types/enums.hpp
@@ -3,7 +3,7 @@
 namespace fast_chess {
 
 enum class NotationType { SAN, LAN, UCI };
-enum class OrderType { RANDOM, SEQUENTIAL };
+enum class OrderType { RANDOM, SEQUENTIAL, NONE };
 enum class FormatType { EPD, PGN, NONE };
 enum class VariantType { STANDARD, FRC };
 enum class OutputType {

--- a/app/src/types/opening.hpp
+++ b/app/src/types/opening.hpp
@@ -12,7 +12,7 @@ struct Opening {
     FormatType format = FormatType::NONE;
 
 #ifdef USE_CUTE
-    OrderType order   = OrderType::SEQUENTIAL;
+    OrderType order   = OrderType::NONE;
 #else
     OrderType order   = OrderType::RANDOM;
 #endif


### PR DESCRIPTION
as per the suggestion of @robertnurnberg , make it so that opening order have to be specified for cutechess build