### PR TITLE
fix: racy behavior for "Finished game" message

### DIFF
--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -65,8 +65,6 @@ void RoundRobin::create() {
         // callback functions, do not capture by reference
         const auto finish = [this, configs, first, second, game_id, round_id](
                                 const Stats& stats, const std::string& reason, const engines& engines) {
-            output_->endGame(configs, stats, reason, game_id);
-
             const auto& cfg = config::TournamentConfig.get();
 
             // lock to avoid chaotic output, i.e.
@@ -75,6 +73,8 @@ void RoundRobin::create() {
             // Score of Engine1 vs Engine2: 95 - 92 - 0  [0.508] 187
             // Score of Engine1 vs Engine2: 94 - 92 - 0  [0.505] 186
             std::lock_guard<std::mutex> lock(output_mutex_);
+
+            output_->endGame(configs, stats, reason, game_id);
 
             bool report = cfg.report_penta ? scoreboard_.updatePair(configs, stats, round_id)
                                            : scoreboard_.updateNonPair(configs, stats);


### PR DESCRIPTION
prevent cases where finished game is printed twice before the scoreline, as this may affect fishtest parsing.

prevents this:
```
Finished game 64 (Engine2 vs Engine1): 1-0 {Black loses on time}
Finished game 63 (Engine1 vs Engine2): 1-0 {Black loses on time}
Score of Engine1 vs Engine2: 38 - 25 - 0  [0.603] 63
Started game 67 of 100 (Engine1 vs Engine2)
Score of Engine1 vs Engine2: 39 - 25 - 0  [0.609] 64
```

fix from https://github.com/Disservin/fast-chess/pull/569