### PR TITLE
fix: sprt fmt wrong formatting when output format=cutechess

### DIFF
--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -46,7 +46,7 @@ class Cutechess : public IOutput {
                 result = " - H0 was accepted";
             }
 
-            return fmt::format("SPRT: llr {:.2f} ({:.1f}%), lbound {}, ubound {}{}\n", llr, percentage, lowerBound,
+            return fmt::format("SPRT: llr {:.2f} ({:.1f}%), lbound {:.2f}, ubound {:.2f}{}\n", llr, percentage, lowerBound,
                                upperBound, result);
         }
         return "";

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -46,7 +46,7 @@ class Cutechess : public IOutput {
                 result = " - H0 was accepted";
             }
 
-            return fmt::format("SPRT: llr {.2f} ({.1f}%), lbound {}, ubound {}{}\n", llr, percentage, lowerBound,
+            return fmt::format("SPRT: llr {:.2f} ({:.1f}%), lbound {}, ubound {}{}\n", llr, percentage, lowerBound,
                                upperBound, result);
         }
         return "";


### PR DESCRIPTION
fix https://github.com/Disservin/fast-chess/issues/602