### PR TITLE
fix: seed not getting randomized

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -482,6 +482,7 @@ void parseScoreinterval(const std::vector<std::string> &params, ArgumentData &ar
 
 void parseSRand(const std::vector<std::string> &params, ArgumentData &argument_data) {
     parseValue(params, argument_data.tournament_config.seed);
+    argument_data.tournament_config.randomize_seed = false;
 }
 
 void parseVersion(const std::vector<std::string> &, ArgumentData &) { OptionsParser::printVersion(); }

--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -624,10 +624,6 @@ OptionsParser::OptionsParser(int argc, char const *argv[]) {
     for (auto &config : argument_data_.configs) {
         config.variant = argument_data_.tournament_config.variant;
     }
-
-    const auto seed = util::random::random_uint64();
-
-    util::random::seed(seed);
 }
 
 }  // namespace fast_chess::cli

--- a/app/src/config/sanitize.cpp
+++ b/app/src/config/sanitize.cpp
@@ -13,6 +13,11 @@
 namespace fast_chess::config {
 
 void sanitize(config::Tournament& config) {
+    if (config.randomize_seed) {
+        uint64_t seed = util::random::random_uint64();
+        util::random::seed(seed);
+    }
+    
     if (config.games > 2) {
         // wrong config, lets try to fix it
         std::swap(config.games, config.rounds);

--- a/app/src/config/sanitize.cpp
+++ b/app/src/config/sanitize.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <util/file_system.hpp>
+#include <util/rand.hpp>
 #include <util/logger/logger.hpp>
 
 namespace fast_chess::config {

--- a/app/src/config/sanitize.cpp
+++ b/app/src/config/sanitize.cpp
@@ -16,6 +16,9 @@ void sanitize(config::Tournament& config) {
     if (config.randomize_seed) {
         uint64_t seed = util::random::random_uint64();
         util::random::seed(seed);
+        
+        // make sure that seed does not get randomized when loading from config
+        config.randomize_seed = false;
     }
     
     if (config.games > 2) {

--- a/app/src/types/tournament.hpp
+++ b/app/src/types/tournament.hpp
@@ -3,7 +3,6 @@
 #include <string>
 
 #include <util/helper.hpp>
-#include <util/rand.hpp>
 
 #include <types/draw_adjudication.hpp>
 #include <types/engine_config.hpp>
@@ -50,7 +49,7 @@ struct Tournament {
     bool report_penta    = true;
 #endif
 
-    uint64_t seed = util::random::random_uint64();
+    uint64_t seed = 951356066;
 
     int scoreinterval = 1;
 
@@ -61,10 +60,11 @@ struct Tournament {
     bool recover          = false;
     bool affinity         = false;
     bool realtime_logging = true;
+    bool randomize_seed   = true;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ORDERED_JSON(Tournament, resign, draw, maxmoves, opening, pgn, epd, sprt,
                                                 config_name, output, seed, variant, ratinginterval, scoreinterval,
                                                 autosaveinterval, games, rounds, concurrency, overhead, recover, noswap,
-                                                report_penta, affinity, realtime_logging)
+                                                report_penta, affinity, realtime_logging, randomize_seed)
 
 }  // namespace fast_chess::config

--- a/app/src/types/tournament.hpp
+++ b/app/src/types/tournament.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <util/helper.hpp>
+#include <util/rand.hpp>
 
 #include <types/draw_adjudication.hpp>
 #include <types/engine_config.hpp>

--- a/app/src/types/tournament.hpp
+++ b/app/src/types/tournament.hpp
@@ -49,7 +49,7 @@ struct Tournament {
     bool report_penta    = true;
 #endif
 
-    uint64_t seed = 951356066;
+    uint64_t seed = util::random::random_uint64();
 
     int scoreinterval = 1;
 


### PR DESCRIPTION
@Disservin this does not work https://github.com/Disservin/fast-chess/pull/573/commits/22f57c22c74574b08ea3424bb55a6077ed1818de the randomized seed just gets overwritten by the default seed in types/tournament.hpp