### PR TITLE
refactor: add "normal" termination tag for pgn

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -161,6 +161,7 @@ bool Match::playMove(Player& us, Player& them) {
     }
 
     if (gameover.first != GameResultReason::NONE) {
+        data_.termination = MatchTermination::NORMAL;
         data_.reason = convertChessReason(getColorString(), gameover.first);
         return false;
     }

--- a/app/src/pgn/pgn_builder.cpp
+++ b/app/src/pgn/pgn_builder.cpp
@@ -166,6 +166,8 @@ std::string PgnBuilder::getResultFromMatch(const MatchData::PlayerInfo &white,
 
 std::string PgnBuilder::convertMatchTermination(const MatchTermination &res) noexcept {
     switch (res) {
+        case MatchTermination::NORMAL:
+            return "normal";
         case MatchTermination::ADJUDICATION:
             return "adjudication";
         case MatchTermination::DISCONNECT:

--- a/app/src/types/match_data.hpp
+++ b/app/src/types/match_data.hpp
@@ -41,6 +41,7 @@ struct MoveData {
 };
 
 enum class MatchTermination {
+    NORMAL,
     ADJUDICATION,
     TIMEOUT,
     DISCONNECT,

--- a/app/tests/pgn_builder_test.cpp
+++ b/app/tests/pgn_builder_test.cpp
@@ -20,6 +20,8 @@ TEST_SUITE("PGN Builder Tests") {
 
         match_data.fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
+        match_data.termination = MatchTermination::NORMAL;
+
         match_data.reason = "engine2 got checkmated";
 
         config::Pgn pgn_config;
@@ -32,6 +34,7 @@ TEST_SUITE("PGN Builder Tests") {
 [Black "engine2"]
 [Result "1-0"]
 [PlyCount "4"]
+[Termination "normal"]
 [TimeControl "-"]
 
 1. e4 {+1.00/15 1.321s} e5 {+1.23/15 0.430s} 2. Nf3 {+1.45/16 0.310s}
@@ -59,6 +62,8 @@ Nf6 {+10.15/18 1.821s engine2 got checkmated} 1-0
 
         match_data.fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
+        match_data.termination = MatchTermination::NORMAL;
+
         match_data.reason = "engine1 got checkmated";
 
         config::Pgn pgn_config;
@@ -71,6 +76,7 @@ Nf6 {+10.15/18 1.821s engine2 got checkmated} 1-0
 [Black "engine2"]
 [Result "0-1"]
 [PlyCount "4"]
+[Termination "normal"]
 [TimeControl "-"]
 
 1. e4 {+1.00/15 1.321s} e5 {+1.23/15 0.430s} 2. Nf3 {+1.45/16 0.310s}


### PR DESCRIPTION
this is part of the pgn standard http://www.saremba.de/chessgml/standards/pgn/pgn-complete.htm#c9.8.1 goal is to make it easier to filter out normal matches with adjudications/disconnects/illegal moves etc...