### PR TITLE
refactor: split engine timeout times into 3 categories

### DIFF
--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -102,7 +102,7 @@ bool UciEngine::ucinewgame() {
             return false;
         }
 
-        return isready(initialize_time);
+        return isready(ucinewgame_time_);
     } catch (const std::exception &e) {
         Logger::trace<true>("Raised Exception in ucinewgame: {}", e.what());
         return false;
@@ -121,10 +121,10 @@ bool UciEngine::uci() {
     return res;
 }
 
-bool UciEngine::uciok() {
+bool UciEngine::uciok(std::chrono::milliseconds threshold) {
     Logger::trace<true>("Waiting for uciok from engine {}", config_.name);
 
-    const auto res = readEngine("uciok") == process::Status::OK;
+    const auto res = readEngine("uciok", threshold) == process::Status::OK;
 
     for (const auto &line : output_) {
         Logger::readFromEngine(line.line, line.time, config_.name, line.std == process::Standard::ERR);
@@ -190,8 +190,8 @@ bool UciEngine::start() {
         return false;
     }
 
-    if (!uci() || !uciok()) {
-        Logger::warn<true>("Engine {} didn't respond to uci/uciok after startup.", config_.name);
+    if (!uci() || !uciok(startup_time_)) {
+        Logger::warn<true>("Engine {} didn't respond to uci with uciok after startup.", config_.name);
         return false;
     }
 

--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -44,7 +44,7 @@ class UciEngine : protected process::Process {
     bool refreshUci();
 
     [[nodiscard]] bool uci();
-    [[nodiscard]] bool uciok();
+    [[nodiscard]] bool uciok(std::chrono::milliseconds threshold = ping_time_);
     [[nodiscard]] bool ucinewgame();
 
     // Sends "isready" to the engine
@@ -91,14 +91,9 @@ class UciEngine : protected process::Process {
     [[nodiscard]] const EngineConfiguration &getConfig() const noexcept { return config_; }
 
     // @TODO: expose this to the user
-    static constexpr std::chrono::milliseconds initialize_time = std::chrono::milliseconds(60000);
-    static constexpr std::chrono::milliseconds ping_time_      = std::chrono::milliseconds(
-#ifdef NDEBUG
-        60000
-#else
-        60000
-#endif
-    );
+    static constexpr std::chrono::milliseconds startup_time_    = std::chrono::seconds(5);
+    static constexpr std::chrono::milliseconds ucinewgame_time_ = std::chrono::seconds(60);
+    static constexpr std::chrono::milliseconds ping_time_       = std::chrono::seconds(60);
 
     [[nodiscard]] const UCIOptions &uciOptions() const noexcept { return uci_options_; }
     UCIOptions &uciOptions() noexcept { return uci_options_; }


### PR DESCRIPTION
engines need to answer to first uci within 5 seconds