### PR TITLE
fix: correctly read book moves after an illegal move

### DIFF
--- a/app/tests/data/test_invalid.pgn
+++ b/app/tests/data/test_invalid.pgn
@@ -1,0 +1,3 @@
+[Result "*"]
+
+1. Nf3 f5 2. c4 Nf6 3. g3 e6 4. Ka1 d5 5. O-O c6 6. d3 Bd6 7. Nc3 dxc4 8. dxc4 e5 *

--- a/app/tests/pgn_reader_test.cpp
+++ b/app/tests/pgn_reader_test.cpp
@@ -108,5 +108,36 @@ TEST_SUITE("PGN Reader") {
             }
         }
     }
+
+    TEST_CASE("Read PGN file with plies limit") {
+        pgn::PgnReader reader("app/tests/data/test.pgn", 5);
+        const auto games = reader.getOpenings();
+
+        CHECK(games.size() == 6);
+
+        CHECK(games[0].fen == chess::constants::STARTPOS);
+        CHECK(games[1].fen == chess::constants::STARTPOS);
+        CHECK(games[2].fen == chess::constants::STARTPOS);
+        CHECK(games[3].fen == "5k2/3r1p2/1p3pp1/p2n3p/P6P/1PPR1PP1/3KN3/6b1 w - - 0 34");
+        CHECK(games[4].fen == "5k2/5p2/4B2p/r5pn/4P3/5PPP/2NR2K1/8 b - - 0 59");
+        CHECK(games[5].fen == "8/p3kp1p/1p4p1/2r2b2/2BR3P/1P3P2/P4PK1/8 b - - 0 28");
+
+        CHECK(games[0].moves.size() == 5);
+        CHECK(games[1].moves.size() == 5);
+        CHECK(games[2].moves.size() == 5);
+        CHECK(games[3].moves.size() == 0);
+        CHECK(games[4].moves.size() == 0);
+        CHECK(games[5].moves.size() == 0);
+    }
+
+    TEST_CASE("Read PGN file with invalid moves") {
+        pgn::PgnReader reader("app/tests/data/test_invalid.pgn");
+        const auto games = reader.getOpenings();
+
+        CHECK(games.size() == 1);
+
+        CHECK(games[0].fen == chess::constants::STARTPOS);
+        CHECK(games[0].moves.size() == 6);
+    }
 }
 }  // namespace fast_chess


### PR DESCRIPTION
fixes https://github.com/Disservin/fast-chess/issues/636