### PR TITLE
fix: compile time usage of ::fmt

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -402,7 +402,7 @@ void Match::verifyPvLines(const Player& us) {
                 auto position = fmt::format("position {}", startpos == "startpos" ? "startpos" : ("fen " + startpos));
                 auto fmt2     = fmt::format("From; {} moves {}", position, str_utils::join(uci_moves, " "));
 
-                Logger::warn<true>(fmt + "\n" + fmt2);
+                Logger::warn<true>("{} \n {}", fmt, "\n", fmt2);
 
                 break;
             }

--- a/app/src/util/logger/logger.hpp
+++ b/app/src/util/logger/logger.hpp
@@ -42,29 +42,29 @@ class Logger {
 
     static void openFile(const std::string &file);
 
-    template <bool thread = false, typename... Args>
-    static void trace(const std::string &format, Args &&...args) {
-        log<Level::TRACE, thread>(format, std::forward<Args>(args)...);
+    template <bool thread = false, typename... T>
+    static void trace(fmt::format_string<T...> format, T &&...args) {
+        log<Level::TRACE, thread>(format, std::forward<T>(args)...);
     }
 
-    template <bool thread = false, typename... Args>
-    static void warn(const std::string &format, Args &&...args) {
-        log<Level::WARN, thread>(format, std::forward<Args>(args)...);
+    template <bool thread = false, typename... T>
+    static void warn(fmt::format_string<T...> format, T &&...args) {
+        log<Level::WARN, thread>(format, std::forward<T>(args)...);
     }
 
-    template <bool thread = false, typename... Args>
-    static void info(const std::string &format, Args &&...args) {
-        log<Level::INFO, thread>(format, std::forward<Args>(args)...);
+    template <bool thread = false, typename... T>
+    static void info(fmt::format_string<T...> format, T &&...args) {
+        log<Level::INFO, thread>(format, std::forward<T>(args)...);
     }
 
-    template <bool thread = false, typename... Args>
-    static void err(const std::string &format, Args &&...args) {
-        log<Level::ERR, thread>(format, std::forward<Args>(args)...);
+    template <bool thread = false, typename... T>
+    static void err(fmt::format_string<T...> format, T &&...args) {
+        log<Level::ERR, thread>(format, std::forward<T>(args)...);
     }
 
-    template <bool thread = false, typename... Args>
-    static void fatal(const std::string &format, Args &&...args) {
-        log<Level::FATAL, thread>(format, std::forward<Args>(args)...);
+    template <bool thread = false, typename... T>
+    static void fatal(fmt::format_string<T...> format, T &&...args) {
+        log<Level::FATAL, thread>(format, std::forward<T>(args)...);
     }
 
     static void writeToEngine(const std::string &msg, const std::string &time, const std::string &name);
@@ -75,13 +75,13 @@ class Logger {
     static std::atomic_bool should_log_;
 
    private:
-    template <Level level = Level::WARN, bool thread = false, typename... Args>
-    static void log(const std::string &format, Args &&...args) {
+    template <Level level = Level::WARN, bool thread = false, typename... T>
+    static void log(fmt::format_string<T...> format, T &&...args) {
         if (level < level_) {
             return;
         }
 
-        auto message = fmt::format(format + "\n", std::forward<Args>(args)...);
+        const auto message = fmt::format(format, std::forward<T>(args)...) + "\n";
 
         if (level >= Level::WARN) {
             std::cout << message << std::flush;


### PR DESCRIPTION
Updating the Makefile to C++20 showed an compilation error regarding the usage fmt::, so fix it.