### PR TITLE
refactor: introduce counting semaphore

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -11,8 +11,8 @@ BUILDDIR         := tmp
 INCDIR           := src
 
 #Flags, Libraries and Includes
-CXXFLAGS         := -O3 -std=c++20 -Wall -Wextra -DNDEBUG
-CXXFLAGS_TEST	 := -O2 -std=c++20 -Wall -Wextra -pedantic -Wuninitialized -g3 -fno-omit-frame-pointer
+CXXFLAGS         := -O3 -std=c++17 -Wall -Wextra -DNDEBUG
+CXXFLAGS_TEST	 := -O2 -std=c++17 -Wall -Wextra -pedantic -Wuninitialized -g3 -fno-omit-frame-pointer
 INC              := -I$(INCDIR) -Ithird_party
 
 SRC_FILES        := \
@@ -82,7 +82,7 @@ endif
 endif
 
 ifeq ($(build), debug)
-	CXXFLAGS := -O2 -std=c++20 -Wall -Wextra -pedantic -Wuninitialized -g3
+	CXXFLAGS := -O2 -std=c++17 -Wall -Wextra -pedantic -Wuninitialized -g3
 endif
 
 ifeq ($(build), release)

--- a/app/Makefile
+++ b/app/Makefile
@@ -11,8 +11,8 @@ BUILDDIR         := tmp
 INCDIR           := src
 
 #Flags, Libraries and Includes
-CXXFLAGS         := -O3 -std=c++17 -Wall -Wextra -DNDEBUG
-CXXFLAGS_TEST	 := -O2 -std=c++17 -Wall -Wextra -pedantic -Wuninitialized -g3 -fno-omit-frame-pointer
+CXXFLAGS         := -O3 -std=c++20 -Wall -Wextra -DNDEBUG
+CXXFLAGS_TEST	 := -O2 -std=c++20 -Wall -Wextra -pedantic -Wuninitialized -g3 -fno-omit-frame-pointer
 INC              := -I$(INCDIR) -Ithird_party
 
 SRC_FILES        := \
@@ -82,7 +82,7 @@ endif
 endif
 
 ifeq ($(build), debug)
-	CXXFLAGS := -O2 -std=c++17 -Wall -Wextra -pedantic -Wuninitialized -g3
+	CXXFLAGS := -O2 -std=c++20 -Wall -Wextra -pedantic -Wuninitialized -g3
 endif
 
 ifeq ($(build), release)

--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -213,9 +213,7 @@ void UciEngine::sendSetoption(const std::string &name, const std::string &value)
 }
 
 bool UciEngine::start() {
-    if (initialized_) {
-        return true;
-    }
+    if (initialized_) return true;
 
     AcquireSemaphore semaphore_acquire(semaphore);
 

--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -90,8 +90,20 @@ class UciEngine : protected process::Process {
     [[nodiscard]] const std::vector<process::Line> &output() const noexcept { return output_; }
     [[nodiscard]] const EngineConfiguration &getConfig() const noexcept { return config_; }
 
-    // @TODO: expose this to the user
-    static constexpr std::chrono::milliseconds startup_time_    = std::chrono::seconds(25);
+    [[nodiscard]] static std::string getPath(const EngineConfiguration &config) {
+        std::string path = (config.dir == "." ? "" : config.dir) + config.cmd;
+
+#ifndef NO_STD_FILESYSTEM
+        // convert path to a filesystem path
+        auto p = std::filesystem::path(config.dir) / std::filesystem::path(config.cmd);
+        path   = p.string();
+#endif
+
+        return path;
+    }
+
+    // @TODO: expose this to the user?
+    static constexpr std::chrono::milliseconds startup_time_    = std::chrono::seconds(10);
     static constexpr std::chrono::milliseconds ucinewgame_time_ = std::chrono::seconds(60);
     static constexpr std::chrono::milliseconds ping_time_       = std::chrono::seconds(60);
 


### PR DESCRIPTION
Add a counting semaphore for the startup for the engines, up to 16 engines can be spawned simultaneously before having to wait for other engines to finish their initialization.initialization. This allows us to set a lower timeout threshold for the startup time on high core count machines, which will lag behind when spawning hundreds of engines near instantaneously.